### PR TITLE
Fix sleep duration card and unify recovery view

### DIFF
--- a/AthleteHub/AthleteHub/HealthManager.swift
+++ b/AthleteHub/AthleteHub/HealthManager.swift
@@ -466,6 +466,7 @@ class HealthManager: ObservableObject {
             var totalSleep: Double = 0
             var sleepStageDurations: [String: Double] = [:]
             var sleepStages: [SleepStage] = []
+            var rawSamples: [HKCategorySample] = []
 
             for sample in samples {
                 let duration = sample.endDate.timeIntervalSince(sample.startDate) / 3600.0
@@ -477,6 +478,7 @@ class HealthManager: ObservableObject {
 
                 sleepStageDurations[stage, default: 0.0] += duration
                 sleepStages.append(SleepStage(stage: stage, startDate: sample.startDate, endDate: sample.endDate))
+                rawSamples.append(sample)
             }
 
             let quality = totalSleep >= 7 ? "Good" : (totalSleep >= 5 ? "Fair" : "Poor")
@@ -485,6 +487,7 @@ class HealthManager: ObservableObject {
                 self.sleepDuration = totalSleep
                 self.sleepQuality = quality
                 self.sleepStages = sleepStages
+                self.rawSleepSamples = rawSamples
 
                 // ✅ Upload to Firebase
                 self.uploadSleepToFirebase(duration: totalSleep, quality: quality, stages: sleepStageDurations)


### PR DESCRIPTION
## Summary
- update HealthManager to store raw sleep data
- restyle `RecoverySleepDurationCard` and use provided stages data
- display sleep stages as a single bar for a consistent look

## Testing
- `xcodebuild -scheme AthleteHub -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -quiet build` *(fails: xcodebuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ccbaa180832b8042160ec7c2676d