### PR TITLE
Fix sleep metrics and rearrange recovery view

### DIFF
--- a/AthleteHub/AthleteHub/HealthManager.swift
+++ b/AthleteHub/AthleteHub/HealthManager.swift
@@ -470,9 +470,10 @@ class HealthManager: ObservableObject {
 
             for sample in samples {
                 let duration = sample.endDate.timeIntervalSince(sample.startDate) / 3600.0
+                let stageValue = HKCategoryValueSleepAnalysis(rawValue: sample.value)
                 let stage = self.stageDescription(for: sample.value)
 
-                if sample.value != HKCategoryValueSleepAnalysis.awake.rawValue {
+                if let stageValue = stageValue, stageValue != .awake && stageValue != .inBed {
                     totalSleep += duration
                 }
 
@@ -482,10 +483,12 @@ class HealthManager: ObservableObject {
             }
 
             let quality = totalSleep >= 7 ? "Good" : (totalSleep >= 5 ? "Fair" : "Poor")
+            let qualityScore = min(Int((totalSleep / 8.0) * 100), 100)
 
             DispatchQueue.main.async {
                 self.sleepDuration = totalSleep
                 self.sleepQuality = quality
+                self.sleepQualityScore = qualityScore
                 self.sleepStages = sleepStages
                 self.rawSleepSamples = rawSamples
 

--- a/AthleteHub/AthleteHub/RecoveryView.swift
+++ b/AthleteHub/AthleteHub/RecoveryView.swift
@@ -159,12 +159,6 @@ struct RecoveryView: View {
                 }
                 .padding(.horizontal)
 
-                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
-                    ForEach(Array(recoveryCards.enumerated()), id: \.offset) { _, view in
-                        view
-                    }
-                }
-
                 RecoveryChartCard(title: "Sleep Stage Timeline", colorScheme: colorScheme) {
                     if !healthManager.sleepStages.isEmpty {
                         SleepStageHypnogramView(
@@ -179,6 +173,12 @@ struct RecoveryView: View {
                             .frame(maxWidth: .infinity)
                             .background(Color(.secondarySystemBackground))
                             .cornerRadius(12)
+                    }
+                }
+
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
+                    ForEach(Array(recoveryCards.enumerated()), id: \.offset) { _, view in
+                        view
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- compute sleep quality score from fetched sleep data
- ignore in-bed segments when summing sleep duration
- show sleep stage analysis directly below the recovery score

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6864cf009e2c832bb5b1480112bad176