### PR TITLE
Fix sleep visualization

### DIFF
--- a/AthleteHub/AthleteHub/HealthManager.swift
+++ b/AthleteHub/AthleteHub/HealthManager.swift
@@ -448,9 +448,9 @@ class HealthManager: ObservableObject {
             return
         }
 
-        let calendar = Calendar.current
-        let startOfYesterday = calendar.date(byAdding: .day, value: -1, to: calendar.startOfDay(for: Date()))!
-        let predicate = HKQuery.predicateForSamples(withStart: startOfYesterday, end: Date())
+        // Only fetch sleep for the last 24 hours to avoid displaying multiple nights
+        let startDate = Date().addingTimeInterval(-24 * 60 * 60)
+        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: Date())
 
         let query = HKSampleQuery(
             sampleType: type,


### PR DESCRIPTION
## Summary
- refine sleep duration bar by ignoring non-sleep stages
- label and scale sleep stage timeline with stage names and hour ticks
- unify metric card sizing and redesign recovery metric cards
- limit sleep stage timeline width to actual duration

## Testing
- `swift --version`
- `xcodebuild -list | head` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f0d69434832bbbb38797f0f802ce