### PR TITLE
Fix workout distance metric and improve training trend

### DIFF
--- a/AthleteHub/AthleteHub/HealthManager.swift
+++ b/AthleteHub/AthleteHub/HealthManager.swift
@@ -123,7 +123,7 @@ class HealthManager: ObservableObject {
         fetchTotalCalories { _ in self.save() }
         fetchWeeklyDistance { _ in }
         fetchWeeklyHours { _ in }
-        fetchDailyDistance { _ in self.save() }
+        fetchWorkoutDistance { _ in self.save() }
         fetchWorkoutDuration { _ in self.save() }
         fetchRestingHeartRate { _ in self.save() }
         fetchHRV { _ in self.save() }
@@ -172,6 +172,7 @@ class HealthManager: ObservableObject {
                     print("❌ Error saving daily metrics: \(error.localizedDescription)")
                 } else {
                     print("✅ Saved metrics for \(dateString)")
+                    self.updateDailyTrainingScore(Int(self.calculateOverallTrainingScore()))
                 }
             }
     }
@@ -341,12 +342,36 @@ class HealthManager: ObservableObject {
         let predicate = HKQuery.predicateForSamples(withStart: startOfDay, end: Date(), options: .strictStartDate)
 
         let query = HKStatisticsQuery(quantityType: type, quantitySamplePredicate: predicate, options: .cumulativeSum) { _, result, _ in
-            let km = result?.sumQuantity()?.doubleValue(for: .meter()) ?? 0 / 1000
+            let meters = result?.sumQuantity()?.doubleValue(for: .meter()) ?? 0
+            let km = meters / 1000
             DispatchQueue.main.async {
                 self.distance = km
                 completion(km)
             }
         }
+        healthStore.execute(query)
+    }
+
+    func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
+        let workoutType = HKObjectType.workoutType()
+        let startOfDay = Calendar.current.startOfDay(for: Date())
+        let predicate = HKQuery.predicateForSamples(withStart: startOfDay, end: Date(), options: .strictStartDate)
+
+        let query = HKSampleQuery(sampleType: workoutType, predicate: predicate, limit: HKObjectQueryNoLimit, sortDescriptors: nil) { _, samples, error in
+            guard let workouts = samples as? [HKWorkout], error == nil else {
+                DispatchQueue.main.async { completion(nil) }
+                return
+            }
+
+            let meters = workouts.reduce(0.0) { $0 + ($1.totalDistance?.doubleValue(for: .meter()) ?? 0) }
+            let km = meters / 1000
+
+            DispatchQueue.main.async {
+                self.distance = km
+                completion(km)
+            }
+        }
+
         healthStore.execute(query)
     }
     
@@ -637,6 +662,20 @@ class HealthManager: ObservableObject {
             .collection("trainingScores")
             .document(newScore.id)
             .setData(from: newScore)
+    }
+
+    func updateDailyTrainingScore(_ score: Int) {
+        guard let uid = Auth.auth().currentUser?.uid else { return }
+        let calendar = Calendar.current
+        if let existing = trainingScores.first(where: { calendar.isDate($0.date, inSameDayAs: Date()) }) {
+            try? db.collection("users")
+                .document(uid)
+                .collection("trainingScores")
+                .document(existing.id)
+                .setData(["date": existing.date, "score": score], merge: true)
+        } else {
+            addTrainingScore(score)
+        }
     }
 
     func fetchTrainingScores() {

--- a/AthleteHub/AthleteHub/TrainingView.swift
+++ b/AthleteHub/AthleteHub/TrainingView.swift
@@ -16,6 +16,7 @@ struct TrainingView: View {
     let customYellow = Color(red: 1.0, green: 0.84, blue: 0.2)
 
     var body: some View {
+        let backgroundColor = colorScheme == .dark ? customYellow.opacity(0.1) : Color(.systemGray6)
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
                 HStack {
@@ -131,7 +132,7 @@ struct TrainingView: View {
             }
             .padding(.vertical)
         }
-        .background(customYellow.opacity(0.1).edgesIgnoringSafeArea(.all))
+        .background(backgroundColor.edgesIgnoringSafeArea(.all))
         .sheet(isPresented: $showingSetGoals) {
             SetGoalsView().environmentObject(healthManager)
         }
@@ -328,18 +329,18 @@ struct OverallTrainingScoreCard: View {
 
     var body: some View {
         HStack {
-            Image(systemName: "star.fill")
+            Image(systemName: "figure.run")
                 .font(.largeTitle)
-                .foregroundColor(.white)
+                .foregroundColor(.black)
 
             VStack(alignment: .leading) {
                 Text("Overall Training Score")
                     .font(.headline)
-                    .foregroundColor(.white)
+                    .foregroundColor(.black)
 
                 Text("\(score)")
                     .font(.system(size: 48, weight: .bold))
-                    .foregroundColor(.white)
+                    .foregroundColor(.black)
             }
 
             Spacer()
@@ -349,11 +350,11 @@ struct OverallTrainingScoreCard: View {
                 .fontWeight(.bold)
                 .padding(8)
                 .background(statusColor)
-                .foregroundColor(.white)
+                .foregroundColor(.black)
                 .cornerRadius(12)
         }
         .padding()
-        .background(Color.black)
+        .background(Color.yellow)
         .cornerRadius(20)
     }
 }
@@ -509,11 +510,11 @@ struct RecentWorkoutsCard: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Recent Workouts")
                 .font(.headline)
-                .foregroundColor(.white)
+                .foregroundColor(.primary)
 
             if healthManager.recentWorkouts.isEmpty {
                 Text("Data not available")
-                    .foregroundColor(.gray)
+                    .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding(.vertical, 20)
             } else {
@@ -529,28 +530,28 @@ struct RecentWorkoutsCard: View {
                             VStack(alignment: .leading) {
                                 Text(workout.workoutActivityType.name)
                                     .font(.subheadline)
-                                    .foregroundColor(.white)
+                                    .foregroundColor(.primary)
 
                                 Text(formattedDateTime(workout.startDate))
                                     .font(.caption)
-                                    .foregroundColor(.gray)
+                                    .foregroundColor(.secondary)
                             }
 
                             Spacer()
 
                             Image(systemName: "chevron.right")
-                                .foregroundColor(.gray)
+                                .foregroundColor(.secondary)
                         }
                         .padding(.vertical, 4)
                     }
 
-                    Divider().background(Color.white.opacity(0.2))
+                    Divider().background(Color.primary.opacity(0.2))
                 }
 
             }
         }
         .padding()
-        .background(Color(.secondarySystemBackground))
+        .background(colorScheme == .dark ? Color(.secondarySystemBackground) : Color.white)
         .cornerRadius(16)
         .padding(.horizontal)
         .sheet(isPresented: $showingWorkoutDetail) {


### PR DESCRIPTION
## Summary
- compute daily distance from logged workouts instead of overall walking distance
- store and update daily training score so trends chart populates
- adapt recent workouts card for light mode

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project AthleteHub/AthleteHub.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865d306ab10832b86db616b5e320dbf