### PR TITLE
Fix workout distance metric and improve training trend

### DIFF
--- a/AthleteHub/AthleteHub/HealthManager.swift
+++ b/AthleteHub/AthleteHub/HealthManager.swift
@@ -44,6 +44,13 @@ class HealthManager: ObservableObject {
     @Published var height: Double?
     @Published var dailyGoals: [String: Double] = [:]
     @Published var trainingScores: [TrainingScore] = []
+    /// Scores for the last seven days including today, sorted by date
+    var lastSevenScores: [TrainingScore] {
+        let start = Calendar.current.date(byAdding: .day, value: -6, to: Date()) ?? Date()
+        return trainingScores
+            .filter { $0.date >= Calendar.current.startOfDay(for: start) }
+            .sorted { $0.date < $1.date }
+    }
     @Published var recentWorkouts: [HKWorkout] = []
     @Published var recoveryScore: Double? = nil
     @Published var stressLevel: Double? = nil
@@ -123,7 +130,7 @@ class HealthManager: ObservableObject {
         fetchTotalCalories { _ in self.save() }
         fetchWeeklyDistance { _ in }
         fetchWeeklyHours { _ in }
-        fetchDailyDistance { _ in self.save() }
+        fetchWorkoutDistance { _ in self.save() }
         fetchWorkoutDuration { _ in self.save() }
         fetchRestingHeartRate { _ in self.save() }
         fetchHRV { _ in self.save() }
@@ -172,6 +179,7 @@ class HealthManager: ObservableObject {
                     print("❌ Error saving daily metrics: \(error.localizedDescription)")
                 } else {
                     print("✅ Saved metrics for \(dateString)")
+                    self.updateDailyTrainingScore(Int(self.calculateOverallTrainingScore()))
                 }
             }
     }
@@ -341,12 +349,36 @@ class HealthManager: ObservableObject {
         let predicate = HKQuery.predicateForSamples(withStart: startOfDay, end: Date(), options: .strictStartDate)
 
         let query = HKStatisticsQuery(quantityType: type, quantitySamplePredicate: predicate, options: .cumulativeSum) { _, result, _ in
-            let km = result?.sumQuantity()?.doubleValue(for: .meter()) ?? 0 / 1000
+            let meters = result?.sumQuantity()?.doubleValue(for: .meter()) ?? 0
+            let km = meters / 1000
             DispatchQueue.main.async {
                 self.distance = km
                 completion(km)
             }
         }
+        healthStore.execute(query)
+    }
+
+    func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
+        let workoutType = HKObjectType.workoutType()
+        let startOfDay = Calendar.current.startOfDay(for: Date())
+        let predicate = HKQuery.predicateForSamples(withStart: startOfDay, end: Date(), options: .strictStartDate)
+
+        let query = HKSampleQuery(sampleType: workoutType, predicate: predicate, limit: HKObjectQueryNoLimit, sortDescriptors: nil) { _, samples, error in
+            guard let workouts = samples as? [HKWorkout], error == nil else {
+                DispatchQueue.main.async { completion(nil) }
+                return
+            }
+
+            let meters = workouts.reduce(0.0) { $0 + ($1.totalDistance?.doubleValue(for: .meter()) ?? 0) }
+            let km = meters / 1000
+
+            DispatchQueue.main.async {
+                self.distance = km
+                completion(km)
+            }
+        }
+
         healthStore.execute(query)
     }
     
@@ -637,6 +669,20 @@ class HealthManager: ObservableObject {
             .collection("trainingScores")
             .document(newScore.id)
             .setData(from: newScore)
+    }
+
+    func updateDailyTrainingScore(_ score: Int) {
+        guard let uid = Auth.auth().currentUser?.uid else { return }
+        let calendar = Calendar.current
+        if let existing = trainingScores.first(where: { calendar.isDate($0.date, inSameDayAs: Date()) }) {
+            try? db.collection("users")
+                .document(uid)
+                .collection("trainingScores")
+                .document(existing.id)
+                .setData(["date": existing.date, "score": score], merge: true)
+        } else {
+            addTrainingScore(score)
+        }
     }
 
     func fetchTrainingScores() {

--- a/AthleteHub/AthleteHub/TrainingView.swift
+++ b/AthleteHub/AthleteHub/TrainingView.swift
@@ -16,6 +16,7 @@ struct TrainingView: View {
     let customYellow = Color(red: 1.0, green: 0.84, blue: 0.2)
 
     var body: some View {
+        let backgroundColor = colorScheme == .dark ? customYellow.opacity(0.1) : Color(.systemGray6)
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
                 HStack {
@@ -93,45 +94,11 @@ struct TrainingView: View {
 
                 RecentWorkoutsCard(healthManager: healthManager, colorScheme: colorScheme)
                 
-                // 7-Day Training Score Trend
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack {
-                        Text("Overall Training – 7 Day Trends")
-                            .font(.headline)
-                            .foregroundColor(.primary)
-                        Spacer()
-                        Button(action: {
-                            showingManualEntry = true
-                        }) {
-                            Image(systemName: "plus.circle")
-                        }
-                    }
-                    .padding(.horizontal)
-
-                    if healthManager.trainingScores.isEmpty {
-                        Text("No training scores yet.")
-                            .foregroundColor(.secondary)
-                            .padding(.horizontal)
-                    } else {
-                        Chart(healthManager.trainingScores) { entry in
-                            LineMark(
-                                x: .value("Date", entry.date),
-                                y: .value("Score", entry.score)
-                            )
-                            PointMark(
-                                x: .value("Date", entry.date),
-                                y: .value("Score", entry.score)
-                            )
-                        }
-                        .chartYScale(domain: 0...100)
-                        .frame(height: 200)
-                        .padding(.horizontal)
-                    }
-                }
+                TrainingScoreTrendCard(healthManager: healthManager)
             }
             .padding(.vertical)
         }
-        .background(customYellow.opacity(0.1).edgesIgnoringSafeArea(.all))
+        .background(backgroundColor.edgesIgnoringSafeArea(.all))
         .sheet(isPresented: $showingSetGoals) {
             SetGoalsView().environmentObject(healthManager)
         }
@@ -328,18 +295,18 @@ struct OverallTrainingScoreCard: View {
 
     var body: some View {
         HStack {
-            Image(systemName: "star.fill")
+            Image(systemName: "figure.run")
                 .font(.largeTitle)
-                .foregroundColor(.white)
+                .foregroundColor(.black)
 
             VStack(alignment: .leading) {
                 Text("Overall Training Score")
                     .font(.headline)
-                    .foregroundColor(.white)
+                    .foregroundColor(.black)
 
                 Text("\(score)")
                     .font(.system(size: 48, weight: .bold))
-                    .foregroundColor(.white)
+                    .foregroundColor(.black)
             }
 
             Spacer()
@@ -349,11 +316,11 @@ struct OverallTrainingScoreCard: View {
                 .fontWeight(.bold)
                 .padding(8)
                 .background(statusColor)
-                .foregroundColor(.white)
+                .foregroundColor(.black)
                 .cornerRadius(12)
         }
         .padding()
-        .background(Color.black)
+        .background(Color.yellow)
         .cornerRadius(20)
     }
 }
@@ -509,11 +476,11 @@ struct RecentWorkoutsCard: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Recent Workouts")
                 .font(.headline)
-                .foregroundColor(.white)
+                .foregroundColor(.primary)
 
             if healthManager.recentWorkouts.isEmpty {
                 Text("Data not available")
-                    .foregroundColor(.gray)
+                    .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding(.vertical, 20)
             } else {
@@ -529,28 +496,28 @@ struct RecentWorkoutsCard: View {
                             VStack(alignment: .leading) {
                                 Text(workout.workoutActivityType.name)
                                     .font(.subheadline)
-                                    .foregroundColor(.white)
+                                    .foregroundColor(.primary)
 
                                 Text(formattedDateTime(workout.startDate))
                                     .font(.caption)
-                                    .foregroundColor(.gray)
+                                    .foregroundColor(.secondary)
                             }
 
                             Spacer()
 
                             Image(systemName: "chevron.right")
-                                .foregroundColor(.gray)
+                                .foregroundColor(.secondary)
                         }
                         .padding(.vertical, 4)
                     }
 
-                    Divider().background(Color.white.opacity(0.2))
+                    Divider().background(Color.primary.opacity(0.2))
                 }
 
             }
         }
         .padding()
-        .background(Color(.secondarySystemBackground))
+        .background(colorScheme == .dark ? Color(.secondarySystemBackground) : Color.white)
         .cornerRadius(16)
         .padding(.horizontal)
         .sheet(isPresented: $showingWorkoutDetail) {
@@ -568,6 +535,49 @@ struct RecentWorkoutsCard: View {
         formatter.dateStyle = .short
         formatter.timeStyle = .short
         return formatter.string(from: date)
+    }
+}
+
+struct TrainingScoreTrendCard: View {
+    @ObservedObject var healthManager: HealthManager
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Overall Training – 7 Day Trends")
+                .font(.headline)
+                .foregroundColor(.primary)
+
+            if healthManager.lastSevenScores.isEmpty {
+                Text("No training scores yet.")
+                    .foregroundColor(.secondary)
+            } else {
+                Chart(healthManager.lastSevenScores) { entry in
+                    LineMark(
+                        x: .value("Date", entry.date),
+                        y: .value("Score", entry.score)
+                    )
+                    .interpolationMethod(.linear)
+
+                    PointMark(
+                        x: .value("Date", entry.date),
+                        y: .value("Score", entry.score)
+                    )
+                }
+                .chartYScale(domain: 0...100)
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .day)) { value in
+                        AxisGridLine()
+                        AxisTick()
+                        AxisValueLabel(format: .dateTime.month().day(), centered: true)
+                    }
+                }
+                .frame(height: 200)
+            }
+        }
+        .padding()
+        .background(Color(.systemGray6))
+        .cornerRadius(16)
+        .padding(.horizontal)
     }
 }
 


### PR DESCRIPTION
## Summary
- compute daily distance from logged workouts instead of overall walking distance
- store and update daily training score so trends chart populates
- adapt recent workouts card for light mode
- show training scores from last seven days on a new trend card
- label dates on the trend chart with connector lines

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project AthleteHub/AthleteHub.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865d306ab10832b86db616b5e320dbf