### PR TITLE
Improve training trend card

### DIFF
--- a/AthleteHub/AthleteHub/TrainingView.swift
+++ b/AthleteHub/AthleteHub/TrainingView.swift
@@ -16,6 +16,7 @@ struct TrainingView: View {
     let customYellow = Color(red: 1.0, green: 0.84, blue: 0.2)
 
     var body: some View {
+        let backgroundColor = colorScheme == .dark ? customYellow.opacity(0.1) : Color(.systemGray6)
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
                 HStack {
@@ -93,45 +94,11 @@ struct TrainingView: View {
 
                 RecentWorkoutsCard(healthManager: healthManager, colorScheme: colorScheme)
                 
-                // 7-Day Training Score Trend
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack {
-                        Text("Overall Training – 7 Day Trends")
-                            .font(.headline)
-                            .foregroundColor(.primary)
-                        Spacer()
-                        Button(action: {
-                            showingManualEntry = true
-                        }) {
-                            Image(systemName: "plus.circle")
-                        }
-                    }
-                    .padding(.horizontal)
-
-                    if healthManager.trainingScores.isEmpty {
-                        Text("No training scores yet.")
-                            .foregroundColor(.secondary)
-                            .padding(.horizontal)
-                    } else {
-                        Chart(healthManager.trainingScores) { entry in
-                            LineMark(
-                                x: .value("Date", entry.date),
-                                y: .value("Score", entry.score)
-                            )
-                            PointMark(
-                                x: .value("Date", entry.date),
-                                y: .value("Score", entry.score)
-                            )
-                        }
-                        .chartYScale(domain: 0...100)
-                        .frame(height: 200)
-                        .padding(.horizontal)
-                    }
-                }
+                TrainingScoreTrendCard(healthManager: healthManager)
             }
             .padding(.vertical)
         }
-        .background(customYellow.opacity(0.1).edgesIgnoringSafeArea(.all))
+        .background(backgroundColor.edgesIgnoringSafeArea(.all))
         .sheet(isPresented: $showingSetGoals) {
             SetGoalsView().environmentObject(healthManager)
         }
@@ -328,18 +295,18 @@ struct OverallTrainingScoreCard: View {
 
     var body: some View {
         HStack {
-            Image(systemName: "star.fill")
+            Image(systemName: "figure.run")
                 .font(.largeTitle)
-                .foregroundColor(.white)
+                .foregroundColor(.black)
 
             VStack(alignment: .leading) {
                 Text("Overall Training Score")
                     .font(.headline)
-                    .foregroundColor(.white)
+                    .foregroundColor(.black)
 
                 Text("\(score)")
                     .font(.system(size: 48, weight: .bold))
-                    .foregroundColor(.white)
+                    .foregroundColor(.black)
             }
 
             Spacer()
@@ -349,11 +316,11 @@ struct OverallTrainingScoreCard: View {
                 .fontWeight(.bold)
                 .padding(8)
                 .background(statusColor)
-                .foregroundColor(.white)
+                .foregroundColor(.black)
                 .cornerRadius(12)
         }
         .padding()
-        .background(Color.black)
+        .background(Color.yellow)
         .cornerRadius(20)
     }
 }
@@ -509,11 +476,11 @@ struct RecentWorkoutsCard: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Recent Workouts")
                 .font(.headline)
-                .foregroundColor(.white)
+                .foregroundColor(.primary)
 
             if healthManager.recentWorkouts.isEmpty {
                 Text("Data not available")
-                    .foregroundColor(.gray)
+                    .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding(.vertical, 20)
             } else {
@@ -529,29 +496,30 @@ struct RecentWorkoutsCard: View {
                             VStack(alignment: .leading) {
                                 Text(workout.workoutActivityType.name)
                                     .font(.subheadline)
-                                    .foregroundColor(.white)
+                                    .foregroundColor(.primary)
 
                                 Text(formattedDateTime(workout.startDate))
                                     .font(.caption)
-                                    .foregroundColor(.gray)
+                                    .foregroundColor(.secondary)
                             }
 
                             Spacer()
 
                             Image(systemName: "chevron.right")
-                                .foregroundColor(.gray)
+                                .foregroundColor(.secondary)
                         }
                         .padding(.vertical, 4)
                     }
 
-                    Divider().background(Color.white.opacity(0.2))
+                    Divider().background(Color.primary.opacity(0.2))
                 }
 
             }
         }
         .padding()
-        .background(Color(.secondarySystemBackground))
+        .background(colorScheme == .dark ? Color(.secondarySystemBackground) : Color.white)
         .cornerRadius(16)
+        .shadow(color: customYellow.opacity(0.4), radius: 8, x: 0, y: 4)
         .padding(.horizontal)
         .sheet(isPresented: $showingWorkoutDetail) {
             if let workout = selectedWorkout {
@@ -568,6 +536,51 @@ struct RecentWorkoutsCard: View {
         formatter.dateStyle = .short
         formatter.timeStyle = .short
         return formatter.string(from: date)
+    }
+}
+
+struct TrainingScoreTrendCard: View {
+    @ObservedObject var healthManager: HealthManager
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Overall Training – 7 Day Trends")
+                .font(.headline)
+                .foregroundColor(.primary)
+
+            if healthManager.lastSevenScoresFilled.allSatisfy({ $0.score == 0 }) {
+                Text("No training scores yet.")
+                    .foregroundColor(.secondary)
+            } else {
+                Chart(healthManager.lastSevenScoresFilled) { entry in
+                    LineMark(
+                        x: .value("Date", entry.date),
+                        y: .value("Score", entry.score)
+                    )
+                    .interpolationMethod(.linear)
+
+                    PointMark(
+                        x: .value("Date", entry.date),
+                        y: .value("Score", entry.score)
+                    )
+                }
+                .chartYScale(domain: 0...100)
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .day)) { value in
+                        AxisGridLine()
+                        AxisTick()
+                        AxisValueLabel(format: .dateTime.month().day(), centered: true)
+                    }
+                }
+                .frame(height: 200)
+            }
+        }
+        .padding()
+        .background(colorScheme == .dark ? Color(.secondarySystemBackground) : Color.white)
+        .cornerRadius(16)
+        .shadow(color: customYellow.opacity(0.4), radius: 8, x: 0, y: 4)
+        .padding(.horizontal)
     }
 }
 


### PR DESCRIPTION
## Summary
- fill in missing days when showing 7-day training scores
- adapt the trend card to light and dark mode
- plot last seven scores with line and point marks
- load past training scores from each day's metrics
- add yellow shadows to workout and trend cards

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project AthleteHub/AthleteHub.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865d306ab10832b86db616b5e320dbf