### PR TITLE
Fix LaunchScreen storyboard usage

### DIFF
--- a/AthleteHub/AthleteHub.xcodeproj/project.pbxproj
+++ b/AthleteHub/AthleteHub.xcodeproj/project.pbxproj
@@ -443,7 +443,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Athletehub/Info.plist";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                               INFOPLIST_KEY_UILaunchScreen_Generation = NO;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -474,7 +474,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Athletehub/Info.plist";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                               INFOPLIST_KEY_UILaunchScreen_Generation = NO;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
## Summary
- disable automatic launch screen generation so LaunchScreen.storyboard is used

## Testing
- `xcodebuild -list -project AthleteHub/AthleteHub.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e50c700c832bb2d87b4683541eb5