### PR TITLE
Update HRV chart layout

### DIFF
--- a/AthleteHub/AthleteHub/RecoveryView.swift
+++ b/AthleteHub/AthleteHub/RecoveryView.swift
@@ -100,13 +100,6 @@ struct RecoveryView: View {
                     colorScheme: colorScheme
                 )
             ),
-            AnyView(
-                HRVChartCard(
-                    values: healthManager.hrvWeek,
-                    colorScheme: colorScheme
-                )
-                .gridCellColumns(2)
-            )
         ]
     }
 
@@ -164,6 +157,11 @@ struct RecoveryView: View {
                             .cornerRadius(12)
                     }
                 }
+
+                HRVChartCard(
+                    values: healthManager.hrvWeek,
+                    colorScheme: colorScheme
+                )
 
                 LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
                     ForEach(Array(recoveryCards.enumerated()), id: \.offset) { _, view in
@@ -459,10 +457,7 @@ struct HRVChartCard: View {
     let colorScheme: ColorScheme
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("HRV Avg (7d)")
-                .font(.headline)
-
+        RecoveryChartCard(title: "HRV Avg (7d)", colorScheme: colorScheme) {
             if #available(iOS 16.0, *) {
                 Chart {
                     ForEach(values.indices, id: \.self) { i in
@@ -477,20 +472,16 @@ struct HRVChartCard: View {
                     }
                 }
                 .chartYScale(domain: 0...(values.max() ?? 1))
-                .frame(height: 120)
+                .frame(height: 140)
             } else {
                 Text("Available on iOS 16+")
                     .foregroundColor(.secondary)
+                    .frame(height: 150)
+                    .frame(maxWidth: .infinity)
+                    .background(Color(.secondarySystemBackground))
+                    .cornerRadius(12)
             }
-
-            Spacer()
         }
-        .padding()
-        .frame(maxWidth: .infinity)
-        .frame(height: 180)
-        .background(colorScheme == .dark ? Color(.secondarySystemBackground) : Color(.systemBackground))
-        .cornerRadius(16)
-        .shadow(color: Color.purple.opacity(0.15), radius: 8, x: 0, y: 4)
     }
 }
 


### PR DESCRIPTION
## Summary
- remove HRV chart from metric grid
- display HRV as its own chart card like the sleep timeline
- reuse `RecoveryChartCard` styling for HRV chart

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6865f94880e0832bb383b80344e2bb61