### PR TITLE
Compute recovery score

### DIFF
--- a/AthleteHub/AthleteHub/RecoveryView.swift
+++ b/AthleteHub/AthleteHub/RecoveryView.swift
@@ -134,7 +134,7 @@ struct RecoveryView: View {
                     }
 
                     OverallRecoveryScoreCard(
-                        score: Int(userProfile.overallRecoveryScore?.replacingOccurrences(of: "%", with: "") ?? "0") ?? 0,
+                        score: Int(healthManager.recoveryScore ?? Double(userProfile.overallRecoveryScore?.replacingOccurrences(of: "%", with: "") ?? "0") ?? 0),
                         colorScheme: colorScheme
                     )
                 }


### PR DESCRIPTION
## Summary
- add calculation for overall recovery score in `HealthManager`
- persist the recovery score when metrics are saved
- include recovery score when entering manual recovery data
- show latest recovery score in RecoveryView

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866004ef524832ba97a113235b231ac