### PR TITLE
Adjust recovery layout and unify card styling

### DIFF
--- a/AthleteHub/AthleteHub/DashboardView.swift
+++ b/AthleteHub/AthleteHub/DashboardView.swift
@@ -109,7 +109,7 @@ struct DashboardView: View {
                             .frame(maxWidth: .infinity)
                             .background(sectionBackground)
                             .cornerRadius(12)
-                            .shadow(color: Color.black.opacity(0.15), radius: 12, x: 0, y: 6)
+                            .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
                             .padding(.horizontal)
                         } else {
                             ForEach(userProfile.trainingLog, id: \.self) { session in
@@ -121,7 +121,7 @@ struct DashboardView: View {
                                 .padding()
                                 .background(cardBackground)
                                 .cornerRadius(8)
-                                .shadow(color: Color.black.opacity(0.1), radius: 6, x: 0, y: 4)
+                                .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
                                 .padding(.horizontal)
                             }
                         }
@@ -180,7 +180,7 @@ struct DashboardMetricCard: View {
         .frame(height: 120)
         .background(cardBackground)
         .cornerRadius(12)
-        .shadow(color: Color.black.opacity(0.15), radius: 12, x: 0, y: 6)
+        .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
     }
 }
 
@@ -203,6 +203,6 @@ struct StatCard: View {
         .frame(maxWidth: .infinity)
         .background(cardBackground)
         .cornerRadius(12)
-        .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 4)
+        .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
     }
 }

--- a/AthleteHub/AthleteHub/NutritionView.swift
+++ b/AthleteHub/AthleteHub/NutritionView.swift
@@ -151,7 +151,7 @@ struct NutritionMetricCard: View {
         .padding()
         .background(colorScheme == .dark ? Color(.systemGray6) : Color.white)
         .cornerRadius(12)
-        .shadow(color: Color.green.opacity(0.4), radius: 8, x: 0, y: 4)
+        .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
     }
 }
 
@@ -175,7 +175,7 @@ struct NutritionChartCard<Content: View>: View {
         .padding()
         .background(colorScheme == .dark ? Color(.systemGray6) : Color.white)
         .cornerRadius(12)
-        .shadow(color: Color.green.opacity(0.4), radius: 8, x: 0, y: 4)
+        .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
         .padding(.horizontal)
     }
 }

--- a/AthleteHub/AthleteHub/ProfileView.swift
+++ b/AthleteHub/AthleteHub/ProfileView.swift
@@ -321,7 +321,7 @@ struct ProfileInfoBox: View {
         .frame(width: 80, height: 80)
         .background(colorScheme == .dark ? Color(.systemGray5) : Color.white)
         .cornerRadius(20)
-        .shadow(color: shadowColor.opacity(0.2), radius: 8, x: 0, y: 4)
+        .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
     }
 }
 
@@ -356,6 +356,6 @@ struct ProfileOptionRow: View {
         .padding()
         .background(colorScheme == .dark ? Color(.systemGray6) : Color.white)
         .cornerRadius(12)
-        .shadow(color: shadowColor.opacity(0.2), radius: 8, x: 0, y: 4)
+        .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
     }
 }

--- a/AthleteHub/AthleteHub/RecoveryView.swift
+++ b/AthleteHub/AthleteHub/RecoveryView.swift
@@ -53,8 +53,10 @@ struct OverallRecoveryScoreCard: View {
                 .cornerRadius(8)
         }
         .padding()
+        .frame(maxWidth: .infinity)
         .background(Color.purple)
-        .cornerRadius(16)
+        .cornerRadius(12)
+        .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
         .padding(.horizontal)
     }
 }
@@ -140,6 +142,14 @@ struct RecoveryView: View {
                 }
                 .padding(.horizontal)
 
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
+                    ForEach(Array(recoveryCards.enumerated()), id: \.
+offset) { _, view in
+                        view
+                    }
+                }
+                .padding(.horizontal)
+
                 RecoveryChartCard(title: "Sleep Stage Timeline", colorScheme: colorScheme) {
                     if !healthManager.sleepStages.isEmpty {
                         SleepStageHypnogramView(
@@ -182,13 +192,6 @@ struct RecoveryView: View {
                             .cornerRadius(12)
                     }
                 }
-
-                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
-                    ForEach(Array(recoveryCards.enumerated()), id: \.offset) { _, view in
-                        view
-                    }
-                }
-                .padding(.horizontal)
 
                 RecoveryChartCard(title: "HRV Avg (7d)", colorScheme: colorScheme) {
                     if #available(iOS 16.0, *) {
@@ -283,7 +286,7 @@ private var cardBackground: Color {
         .frame(height: 180)
         .background(cardBackground)
         .cornerRadius(16)
-        .shadow(color: Color.purple.opacity(0.15), radius: 8, x: 0, y: 4)
+        .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
     }
 
     private func barWidth(for stage: SleepStage, totalWidth: CGFloat) -> CGFloat {
@@ -357,7 +360,7 @@ struct RecoveryMetricCard: View {
         .frame(height: 180)
         .background(cardBackground)
         .cornerRadius(16)
-        .shadow(color: Color.purple.opacity(0.15), radius: 8, x: 0, y: 4)
+        .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
     }
 }
 
@@ -384,7 +387,7 @@ struct RecoveryChartCard<Content: View>: View {
         .padding()
         .background(colorScheme == .dark ? Color(.systemGray6) : Color.white)
         .cornerRadius(12)
-        .shadow(color: Color.purple.opacity(0.4), radius: 8, x: 0, y: 4)
+        .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
         .padding(.horizontal)
     }
 }
@@ -489,7 +492,7 @@ struct SleepQualityCard: View {
         .frame(height: 180)
         .background(colorScheme == .dark ? Color(.secondarySystemBackground) : Color(.systemBackground))
         .cornerRadius(16)
-        .shadow(color: Color.purple.opacity(0.15), radius: 8, x: 0, y: 4)
+        .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
         .onAppear {
             withAnimation(.easeOut(duration: 1.2)) {
                 animatedProgress = progress
@@ -564,7 +567,7 @@ struct RestingHRScoreCard: View {
         .frame(height: 180)
         .background(colorScheme == .dark ? Color(.secondarySystemBackground) : Color(.systemBackground))
         .cornerRadius(16)
-        .shadow(color: Color.purple.opacity(0.15), radius: 8, x: 0, y: 4)
+        .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
     }
 }
 

--- a/AthleteHub/AthleteHub/TrainingView.swift
+++ b/AthleteHub/AthleteHub/TrainingView.swift
@@ -265,7 +265,7 @@ struct TrainingMetricCard: View {
         .padding()
         .background(colorScheme == .dark ? Color(.systemGray6) : Color.white)
         .cornerRadius(12)
-        .shadow(color: shadowColor.opacity(0.4), radius: 8, x: 0, y: 4)
+        .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
     }
 }
 
@@ -520,7 +520,7 @@ struct RecentWorkoutsCard: View {
         .padding()
         .background(colorScheme == .dark ? Color(.secondarySystemBackground) : Color.white)
         .cornerRadius(16)
-        .shadow(color: customYellow.opacity(0.4), radius: 8, x: 0, y: 4)
+        .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
         .padding(.horizontal)
         .sheet(isPresented: $showingWorkoutDetail) {
             if let workout = selectedWorkout {
@@ -581,7 +581,7 @@ struct TrainingScoreTrendCard: View {
         .padding()
         .background(colorScheme == .dark ? Color(.secondarySystemBackground) : Color.white)
         .cornerRadius(16)
-        .shadow(color: customYellow.opacity(0.4), radius: 8, x: 0, y: 4)
+        .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
         .padding(.horizontal)
     }
 }


### PR DESCRIPTION
## Summary
- show metric cards before charts on the Recovery screen
- match OverallRecoveryScoreCard width and style with chart cards
- use the same drop shadow across all cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686602c9f794832b9ac2f589afd629ff