### PR TITLE
Refine nutrition metric interactions

### DIFF
--- a/AthleteHub/AthleteHub/NutritionView.swift
+++ b/AthleteHub/AthleteHub/NutritionView.swift
@@ -7,29 +7,133 @@ struct NutritionView: View {
     @EnvironmentObject var userProfile: UserProfile
     @EnvironmentObject var healthManager: HealthManager
 
+    @State private var showingSetGoals = false
+    @State private var activeMetric: MetricType?
+
+    private func percentage(from text: String?) -> Double? {
+        guard let stripped = text?.replacingOccurrences(of: "%", with: ""),
+              let value = Double(stripped) else { return nil }
+        return value
+    }
+
+    private var overallNutritionScore: Int {
+        let percentages = [
+            userProfile.caloriesPercentage,
+            userProfile.proteinPercentage,
+            userProfile.carbsPercentage,
+            userProfile.fatPercentage,
+            userProfile.waterPercentage,
+            userProfile.fiberPercentage
+        ]
+        let values = percentages.compactMap { percentage(from: $0) }
+        guard !values.isEmpty else { return 0 }
+        return Int(values.reduce(0, +) / Double(values.count))
+    }
+
+    private func generateNutritionInsights() -> [String] {
+        func message(for percent: Double, metric: String) -> String {
+            if percent >= 100 { return "\(metric) goal met." }
+            return "\(Int(percent))% of \(metric) goal."
+        }
+
+        var insights: [String] = []
+        if let p = percentage(from: userProfile.caloriesPercentage) {
+            insights.append(message(for: p, metric: "calorie"))
+        } else {
+            insights.append("No calorie data yet.")
+        }
+        if let p = percentage(from: userProfile.proteinPercentage) {
+            insights.append(message(for: p, metric: "protein"))
+        }
+        if let p = percentage(from: userProfile.waterPercentage) {
+            insights.append(message(for: p, metric: "water"))
+        }
+        return insights
+    }
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                Text("Nutrition Dashboard")
-                    .font(.title)
-                    .fontWeight(.bold)
-                    .foregroundColor(colorScheme == .dark ? .white : .black)
-                    .padding(.horizontal)
+                HStack {
+                    Text("Nutrition Dashboard")
+                        .font(.title)
+                        .fontWeight(.bold)
+                        .foregroundColor(colorScheme == .dark ? .white : .black)
+                    Spacer()
+                    HStack(spacing: 12) {
+                        Button(action: { showingSetGoals = true }) {
+                            Image(systemName: "target")
+                                .padding(8)
+                                .background(Color.green.opacity(0.2))
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                        }
 
-                // Charts at Top
-                NutritionChartCard(title: "Overall Nutrition Score", colorScheme: colorScheme) {
-                    if userProfile.dailyIntakeTrendsAvailable {
-                        // Insert real chart here
-                    } else {
-                        Text("Data not available")
-                            .foregroundColor(.secondary)
-                            .frame(height: 150)
-                            .frame(maxWidth: .infinity)
-                            .background(Color(.secondarySystemBackground))
-                            .cornerRadius(12)
                     }
                 }
+                .padding(.horizontal)
+
+                OverallNutritionScoreCard(score: overallNutritionScore, colorScheme: colorScheme)
+                    .padding(.horizontal)
+
+                NutritionInsightsCard(insights: generateNutritionInsights(), colorScheme: colorScheme)
+                    .padding(.horizontal)
+
+                // Metric Cards
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
+                    NutritionRingCard(
+                        title: "Calories",
+                        icon: "flame.fill",
+                        value: userProfile.caloriesConsumed ?? "0",
+                        goal: userProfile.caloriesGoal ?? "0 cal",
+                        percentage: userProfile.caloriesPercentage ?? "0%",
+                        ringColor: .orange,
+                        colorScheme: colorScheme,
+                        onTap: { activeMetric = .calories }
+                    )
+
+                    NutritionRingCard(
+                        title: "Protein",
+                        icon: "bolt.fill",
+                        value: userProfile.proteinIntake ?? "0",
+                        goal: userProfile.proteinGoal ?? "0 g",
+                        percentage: userProfile.proteinPercentage ?? "0%",
+                        ringColor: .red,
+                        colorScheme: colorScheme,
+                        onTap: { activeMetric = .protein }
+                    )
+
+                    NutritionRingCard(
+                        title: "Carbs",
+                        icon: "leaf.fill",
+                        value: userProfile.carbsIntake ?? "0",
+                        goal: userProfile.carbsGoal ?? "0 g",
+                        percentage: userProfile.carbsPercentage ?? "0%",
+                        ringColor: .yellow,
+                        colorScheme: colorScheme,
+                        onTap: { activeMetric = .carbs }
+                    )
+
+                    NutritionRingCard(
+                        title: "Fat",
+                        icon: "chart.pie.fill",
+                        value: userProfile.fatIntake ?? "0",
+                        goal: userProfile.fatGoal ?? "0 g",
+                        percentage: userProfile.fatPercentage ?? "0%",
+                        ringColor: .purple,
+                        colorScheme: colorScheme,
+                        onTap: { activeMetric = .fat }
+                    )
+                }
+                .padding(.horizontal)
+
+                WaterIntakeCard(
+                    intake: userProfile.waterIntake ?? "0",
+                    goal: userProfile.waterGoal ?? "0 L",
+                    percentage: userProfile.waterPercentage ?? "0%",
+                    colorScheme: colorScheme,
+                    onTap: { activeMetric = .water }
+                )
+                .padding(.horizontal)
 
                 NutritionChartCard(title: "7-Day Nutrition Trends", colorScheme: colorScheme) {
                     if userProfile.dailyIntakeTrendsAvailable {
@@ -43,117 +147,137 @@ struct NutritionView: View {
                             .cornerRadius(12)
                     }
                 }
-
-                // Metric Cards Below
-                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
-                    NutritionMetricCard(
-                        title: "Calories",
-                        value: userProfile.caloriesConsumed ?? "0",
-                        goal: userProfile.caloriesGoal ?? "0 cal",
-                        percentage: userProfile.caloriesPercentage ?? "0%",
-                        status: userProfile.caloriesStatus ?? "Data not available",
-                        colorScheme: colorScheme
-                    )
-
-                    NutritionMetricCard(
-                        title: "Protein",
-                        value: userProfile.proteinIntake ?? "0",
-                        goal: userProfile.proteinGoal ?? "0 g",
-                        percentage: userProfile.proteinPercentage ?? "0%",
-                        status: userProfile.proteinStatus ?? "Data not available",
-                        colorScheme: colorScheme
-                    )
-
-                    NutritionMetricCard(
-                        title: "Carbs",
-                        value: userProfile.carbsIntake ?? "0",
-                        goal: userProfile.carbsGoal ?? "0 g",
-                        percentage: userProfile.carbsPercentage ?? "0%",
-                        status: userProfile.carbsStatus ?? "Data not available",
-                        colorScheme: colorScheme
-                    )
-
-                    NutritionMetricCard(
-                        title: "Fat",
-                        value: userProfile.fatIntake ?? "0",
-                        goal: userProfile.fatGoal ?? "0 g",
-                        percentage: userProfile.fatPercentage ?? "0%",
-                        status: userProfile.fatStatus ?? "Data not available",
-                        colorScheme: colorScheme
-                    )
-
-                    NutritionMetricCard(
-                        title: "Water",
-                        value: userProfile.waterIntake ?? "0",
-                        goal: userProfile.waterGoal ?? "0 L",
-                        percentage: userProfile.waterPercentage ?? "0%",
-                        status: userProfile.waterStatus ?? "Data not available",
-                        colorScheme: colorScheme
-                    )
-
-                    NutritionMetricCard(
-                        title: "Fiber",
-                        value: userProfile.fiberIntake ?? "0",
-                        goal: userProfile.fiberGoal ?? "0 g",
-                        percentage: userProfile.fiberPercentage ?? "0%",
-                        status: userProfile.fiberStatus ?? "Data not available",
-                        colorScheme: colorScheme
-                    )
-                }
-                .padding(.horizontal)
             }
             .padding(.vertical)
         }
         .background(Color.white.edgesIgnoringSafeArea(.all))
+        .sheet(isPresented: $showingSetGoals) {
+            SetNutritionGoalsView()
+                .environmentObject(userProfile)
+        }
+        .sheet(item: $activeMetric) { metric in
+            MetricDetailView(metric: metric)
+                .environmentObject(userProfile)
+        }
     }
 }
 
-struct NutritionMetricCard: View {
+struct NutritionRingCard: View {
     let title: String
+    let icon: String
     let value: String
     let goal: String
     let percentage: String
-    let status: String
+    let ringColor: Color
     let colorScheme: ColorScheme
+    var onTap: () -> Void = {}
+
+    @State private var animatedProgress: Double = 0.0
+
+    private var progress: Double {
+        (Double(percentage.replacingOccurrences(of: "%", with: "")) ?? 0) / 100.0
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(spacing: 16) {
             HStack {
-                Text(title)
+                Label(title, systemImage: icon)
                     .font(.headline)
                 Spacer()
-                Text(status)
-                    .font(.caption)
-                    .fontWeight(.bold)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(Color.blue.opacity(0.2))
-                    .foregroundColor(.blue)
-                    .cornerRadius(10)
             }
 
-            HStack(alignment: .firstTextBaseline) {
-                Text(value)
-                    .font(.title2)
-                    .fontWeight(.bold)
-                Text("/\(goal)")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-            }
+            ZStack {
+                Circle()
+                    .stroke(Color.gray.opacity(0.2), lineWidth: 10)
+                    .frame(width: 100, height: 100)
 
-            ProgressView(value: Double(percentage.dropLast()) ?? 0, total: 100)
-                .accentColor(.black)
+                Circle()
+                    .trim(from: 0, to: CGFloat(animatedProgress))
+                    .stroke(ringColor, style: StrokeStyle(lineWidth: 10, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                    .frame(width: 100, height: 100)
+
+                VStack {
+                    Text(value)
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    Text("/\(goal)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
 
             Text("\(percentage) of daily target")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .frame(height: 180)
+        .background(colorScheme == .dark ? Color(.secondarySystemBackground) : Color(.systemBackground))
+        .cornerRadius(16)
+        .shadow(color: Color.green.opacity(0.3), radius: 8, x: 0, y: 4)
+        .onAppear {
+            withAnimation(.easeOut(duration: 1.0)) {
+                animatedProgress = progress
+            }
+        }
+        .onTapGesture { onTap() }
+    }
+}
+
+struct WaterIntakeCard: View {
+    let intake: String
+    let goal: String
+    let percentage: String
+    let colorScheme: ColorScheme
+    var onTap: () -> Void = {}
+
+    @State private var animatedProgress: Double = 0.0
+
+    private var progress: Double {
+        (Double(percentage.replacingOccurrences(of: "%", with: "")) ?? 0) / 100.0
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            HStack {
+                Image(systemName: "drop.fill")
+                    .foregroundColor(.blue)
+                Text("Water")
+                    .font(.headline)
+                Spacer()
+            }
+
+            ZStack(alignment: .bottom) {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.blue.opacity(0.2))
+                    .frame(width: 40, height: 100)
+
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.blue)
+                    .frame(width: 40, height: CGFloat(animatedProgress) * 100)
+            }
+
+            Text("\(intake) / \(goal)")
                 .font(.caption)
                 .foregroundColor(.secondary)
         }
         .padding()
-        .background(colorScheme == .dark ? Color(.systemGray6) : Color.white)
-        .cornerRadius(12)
+        .frame(maxWidth: .infinity)
+        .frame(height: 180)
+        .background(colorScheme == .dark ? Color(.secondarySystemBackground) : Color(.systemBackground))
+        .cornerRadius(16)
         .shadow(color: Color.green.opacity(0.3), radius: 8, x: 0, y: 4)
+        .onAppear {
+            withAnimation(.easeOut(duration: 1.0)) {
+                animatedProgress = progress
+            }
+        }
+        .onTapGesture { onTap() }
     }
 }
+
 
 struct NutritionChartCard<Content: View>: View {
     let title: String
@@ -179,3 +303,223 @@ struct NutritionChartCard<Content: View>: View {
         .padding(.horizontal)
     }
 }
+
+struct OverallNutritionScoreCard: View {
+    let score: Int
+    let colorScheme: ColorScheme
+
+    private var statusText: String {
+        if score >= 80 { return "Excellent" }
+        else if score >= 50 { return "Moderate" }
+        else { return "Needs Work" }
+    }
+
+    private var statusColor: Color {
+        if score >= 80 { return .green }
+        else if score >= 50 { return .yellow }
+        else { return .red }
+    }
+
+    var body: some View {
+        HStack {
+            Image(systemName: "leaf")
+                .font(.largeTitle)
+                .foregroundColor(.white)
+
+            VStack(alignment: .leading) {
+                Text("Overall Nutrition Score")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                Text("\(score)")
+                    .font(.system(size: 48, weight: .bold))
+                    .foregroundColor(.white)
+            }
+
+            Spacer()
+
+            Text(statusText)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .padding(8)
+                .background(statusColor.opacity(0.9))
+                .foregroundColor(.white)
+                .cornerRadius(8)
+        }
+        .padding()
+        .background(Color.green)
+        .cornerRadius(12)
+        .shadow(color: Color.green.opacity(0.3), radius: 8, x: 0, y: 4)
+    }
+}
+
+struct NutritionInsightsCard: View {
+    let insights: [String]
+    let colorScheme: ColorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "lightbulb.fill")
+                    .foregroundColor(.green)
+                Text("Nutrition Insights")
+                    .font(.headline)
+                    .foregroundColor(.primary)
+            }
+
+            ForEach(insights, id: \.self) { insight in
+                HStack(alignment: .top) {
+                    Image(systemName: "checkmark.circle")
+                        .foregroundColor(.green)
+                    Text(insight)
+                        .font(.footnote)
+                        .foregroundColor(.primary)
+                }
+            }
+        }
+        .padding()
+        .background(colorScheme == .dark ? Color(.secondarySystemBackground) : Color.white)
+        .cornerRadius(20)
+        .shadow(color: Color.green.opacity(0.3), radius: 8, x: 0, y: 4)
+    }
+}
+
+struct SetNutritionGoalsView: View {
+    @EnvironmentObject var userProfile: UserProfile
+    @Environment(\.presentationMode) var presentationMode
+
+    @State private var calorieGoal: String = ""
+    @State private var proteinGoal: String = ""
+    @State private var carbGoal: String = ""
+    @State private var fatGoal: String = ""
+    @State private var waterGoal: String = ""
+    @State private var fiberGoal: String = ""
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Daily Goals")) {
+                    TextField("Calories", text: $calorieGoal)
+                        .keyboardType(.decimalPad)
+                    TextField("Protein (g)", text: $proteinGoal)
+                        .keyboardType(.decimalPad)
+                    TextField("Carbs (g)", text: $carbGoal)
+                        .keyboardType(.decimalPad)
+                    TextField("Fat (g)", text: $fatGoal)
+                        .keyboardType(.decimalPad)
+                    TextField("Water (L)", text: $waterGoal)
+                        .keyboardType(.decimalPad)
+                    TextField("Fiber (g)", text: $fiberGoal)
+                        .keyboardType(.decimalPad)
+                }
+            }
+            .navigationTitle("Set Nutrition Goals")
+            .navigationBarItems(trailing: Button("Save") {
+                userProfile.caloriesGoal = calorieGoal
+                userProfile.proteinGoal = proteinGoal
+                userProfile.carbsGoal = carbGoal
+                userProfile.fatGoal = fatGoal
+                userProfile.waterGoal = waterGoal
+                userProfile.fiberGoal = fiberGoal
+                userProfile.saveToFirestore()
+                presentationMode.wrappedValue.dismiss()
+            })
+            .onAppear {
+                calorieGoal = userProfile.caloriesGoal ?? ""
+                proteinGoal = userProfile.proteinGoal ?? ""
+                carbGoal = userProfile.carbsGoal ?? ""
+                fatGoal = userProfile.fatGoal ?? ""
+                waterGoal = userProfile.waterGoal ?? ""
+                fiberGoal = userProfile.fiberGoal ?? ""
+            }
+        }
+    }
+}
+
+enum MetricType: String, Identifiable {
+    case calories, protein, carbs, fat, water
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .calories: return "Calories"
+        case .protein:  return "Protein"
+        case .carbs:    return "Carbs"
+        case .fat:      return "Fat"
+        case .water:    return "Water"
+        }
+    }
+}
+
+struct MetricDetailView: View {
+    let metric: MetricType
+    @EnvironmentObject var userProfile: UserProfile
+    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.colorScheme) var colorScheme
+
+    @State private var value: String = ""
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                metricCard
+                    .frame(height: 220)
+
+                TextField("Enter \(metric.title)", text: $value)
+                    .keyboardType(.decimalPad)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding(.horizontal)
+
+                Button("Save") {
+                    save()
+                    presentationMode.wrappedValue.dismiss()
+                }
+                .padding()
+
+                Spacer()
+            }
+            .navigationTitle(metric.title)
+            .navigationBarItems(trailing: Button("Close") {
+                presentationMode.wrappedValue.dismiss()
+            })
+            .onAppear { value = currentValue }
+        }
+    }
+
+    private var metricCard: some View {
+        switch metric {
+        case .calories:
+            return AnyView(NutritionRingCard(title: "Calories", icon: "flame.fill", value: userProfile.caloriesConsumed ?? "0", goal: userProfile.caloriesGoal ?? "0 cal", percentage: userProfile.caloriesPercentage ?? "0%", ringColor: .orange, colorScheme: colorScheme))
+        case .protein:
+            return AnyView(NutritionRingCard(title: "Protein", icon: "bolt.fill", value: userProfile.proteinIntake ?? "0", goal: userProfile.proteinGoal ?? "0 g", percentage: userProfile.proteinPercentage ?? "0%", ringColor: .red, colorScheme: colorScheme))
+        case .carbs:
+            return AnyView(NutritionRingCard(title: "Carbs", icon: "leaf.fill", value: userProfile.carbsIntake ?? "0", goal: userProfile.carbsGoal ?? "0 g", percentage: userProfile.carbsPercentage ?? "0%", ringColor: .yellow, colorScheme: colorScheme))
+        case .fat:
+            return AnyView(NutritionRingCard(title: "Fat", icon: "chart.pie.fill", value: userProfile.fatIntake ?? "0", goal: userProfile.fatGoal ?? "0 g", percentage: userProfile.fatPercentage ?? "0%", ringColor: .purple, colorScheme: colorScheme))
+        case .water:
+            return AnyView(WaterIntakeCard(intake: userProfile.waterIntake ?? "0", goal: userProfile.waterGoal ?? "0 L", percentage: userProfile.waterPercentage ?? "0%", colorScheme: colorScheme))
+        }
+    }
+
+    private var currentValue: String {
+        switch metric {
+        case .calories: return userProfile.caloriesConsumed ?? ""
+        case .protein:  return userProfile.proteinIntake ?? ""
+        case .carbs:    return userProfile.carbsIntake ?? ""
+        case .fat:      return userProfile.fatIntake ?? ""
+        case .water:    return userProfile.waterIntake ?? ""
+        }
+    }
+
+    private func save() {
+        switch metric {
+        case .calories: userProfile.caloriesConsumed = value
+        case .protein:  userProfile.proteinIntake = value
+        case .carbs:    userProfile.carbsIntake = value
+        case .fat:      userProfile.fatIntake = value
+        case .water:    userProfile.waterIntake = value
+        }
+        userProfile.saveToFirestore()
+    }
+}
+


### PR DESCRIPTION
## Summary
- remove old manual nutrition entry sheet
- open new per-metric sheet when tapping cards
- added `MetricDetailView` for editing individual metrics
- make metric and water cards tappable

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swiftc -typecheck AthleteHub/AthleteHub/NutritionView.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_6866097583c0832b9be04271596a3b52