### PR TITLE
Dynamic progress ring colors

### DIFF
--- a/AthleteHub/AthleteHub/NutritionView.swift
+++ b/AthleteHub/AthleteHub/NutritionView.swift
@@ -89,13 +89,13 @@ struct NutritionView: View {
                     .padding(.horizontal)
 
                 LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
-                    NutritionRingCard(title: "Calories", icon: "flame.fill", value: userProfile.caloriesConsumed ?? "0", goal: userProfile.caloriesGoal ?? "0 cal", percentage: userProfile.caloriesPercentage ?? "0%", ringColor: .orange, colorScheme: colorScheme, onTap: { activeMetric = .calories })
+                    NutritionRingCard(title: "Calories", icon: "flame.fill", value: userProfile.caloriesConsumed ?? "0", goal: userProfile.caloriesGoal ?? "0 cal", percentage: userProfile.caloriesPercentage ?? "0%", colorScheme: colorScheme, onTap: { activeMetric = .calories })
 
-                    NutritionRingCard(title: "Protein", icon: "bolt.fill", value: userProfile.proteinIntake ?? "0", goal: userProfile.proteinGoal ?? "0 g", percentage: userProfile.proteinPercentage ?? "0%", ringColor: .red, colorScheme: colorScheme, onTap: { activeMetric = .protein })
+                    NutritionRingCard(title: "Protein", icon: "bolt.fill", value: userProfile.proteinIntake ?? "0", goal: userProfile.proteinGoal ?? "0 g", percentage: userProfile.proteinPercentage ?? "0%", colorScheme: colorScheme, onTap: { activeMetric = .protein })
 
-                    NutritionRingCard(title: "Carbs", icon: "leaf.fill", value: userProfile.carbsIntake ?? "0", goal: userProfile.carbsGoal ?? "0 g", percentage: userProfile.carbsPercentage ?? "0%", ringColor: .yellow, colorScheme: colorScheme, onTap: { activeMetric = .carbs })
+                    NutritionRingCard(title: "Carbs", icon: "leaf.fill", value: userProfile.carbsIntake ?? "0", goal: userProfile.carbsGoal ?? "0 g", percentage: userProfile.carbsPercentage ?? "0%", colorScheme: colorScheme, onTap: { activeMetric = .carbs })
 
-                    NutritionRingCard(title: "Fat", icon: "chart.pie.fill", value: userProfile.fatIntake ?? "0", goal: userProfile.fatGoal ?? "0 g", percentage: userProfile.fatPercentage ?? "0%", ringColor: .purple, colorScheme: colorScheme, onTap: { activeMetric = .fat })
+                    NutritionRingCard(title: "Fat", icon: "chart.pie.fill", value: userProfile.fatIntake ?? "0", goal: userProfile.fatGoal ?? "0 g", percentage: userProfile.fatPercentage ?? "0%", colorScheme: colorScheme, onTap: { activeMetric = .fat })
                 }
                 .padding(.horizontal)
 
@@ -142,7 +142,6 @@ struct NutritionRingCard: View {
     let value: String
     let goal: String
     let percentage: String
-    let ringColor: Color
     let colorScheme: ColorScheme
     var onTap: () -> Void = {}
 
@@ -150,6 +149,17 @@ struct NutritionRingCard: View {
 
     private var progress: Double {
         (Double(percentage.replacingOccurrences(of: "%", with: "")) ?? 0) / 100.0
+    }
+
+    private var ringColor: Color {
+        switch progress {
+        case ..<0.5:
+            return .red
+        case ..<0.75:
+            return .yellow
+        default:
+            return .green
+        }
     }
 
     var body: some View {
@@ -520,13 +530,13 @@ struct MetricDetailView: View {
     private var metricCard: some View {
         switch metric {
         case .calories:
-            return AnyView(NutritionRingCard(title: "Calories", icon: "flame.fill", value: userProfile.caloriesConsumed ?? "0", goal: userProfile.caloriesGoal ?? "0 cal", percentage: userProfile.caloriesPercentage ?? "0%", ringColor: .orange, colorScheme: colorScheme))
+            return AnyView(NutritionRingCard(title: "Calories", icon: "flame.fill", value: userProfile.caloriesConsumed ?? "0", goal: userProfile.caloriesGoal ?? "0 cal", percentage: userProfile.caloriesPercentage ?? "0%", colorScheme: colorScheme))
         case .protein:
-            return AnyView(NutritionRingCard(title: "Protein", icon: "bolt.fill", value: userProfile.proteinIntake ?? "0", goal: userProfile.proteinGoal ?? "0 g", percentage: userProfile.proteinPercentage ?? "0%", ringColor: .red, colorScheme: colorScheme))
+            return AnyView(NutritionRingCard(title: "Protein", icon: "bolt.fill", value: userProfile.proteinIntake ?? "0", goal: userProfile.proteinGoal ?? "0 g", percentage: userProfile.proteinPercentage ?? "0%", colorScheme: colorScheme))
         case .carbs:
-            return AnyView(NutritionRingCard(title: "Carbohydrates", icon: "leaf.fill", value: userProfile.carbsIntake ?? "0", goal: userProfile.carbsGoal ?? "0 g", percentage: userProfile.carbsPercentage ?? "0%", ringColor: .yellow, colorScheme: colorScheme))
+            return AnyView(NutritionRingCard(title: "Carbohydrates", icon: "leaf.fill", value: userProfile.carbsIntake ?? "0", goal: userProfile.carbsGoal ?? "0 g", percentage: userProfile.carbsPercentage ?? "0%", colorScheme: colorScheme))
         case .fat:
-            return AnyView(NutritionRingCard(title: "Fat", icon: "chart.pie.fill", value: userProfile.fatIntake ?? "0", goal: userProfile.fatGoal ?? "0 g", percentage: userProfile.fatPercentage ?? "0%", ringColor: .purple, colorScheme: colorScheme))
+            return AnyView(NutritionRingCard(title: "Fat", icon: "chart.pie.fill", value: userProfile.fatIntake ?? "0", goal: userProfile.fatGoal ?? "0 g", percentage: userProfile.fatPercentage ?? "0%", colorScheme: colorScheme))
         case .water:
             return AnyView(WaterIntakeCard(intake: userProfile.waterIntake ?? "0", goal: userProfile.waterGoal ?? "0 L", percentage: userProfile.waterPercentage ?? "0%", colorScheme: colorScheme))
         }


### PR DESCRIPTION
## Summary
- update NutritionRingCard to color progress rings based on goal completion
- adjust parent views and MetricDetailView to use the new dynamic ring color logic
- keep the water intake ring progress always blue

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68663370c500832bb436ed7a74d0bdd7