### PR TITLE
Add blood oxygen recovery chart

### DIFF
--- a/AthleteHub/AthleteHub/RecoveryView.swift
+++ b/AthleteHub/AthleteHub/RecoveryView.swift
@@ -189,6 +189,32 @@ struct RecoveryView: View {
                             .cornerRadius(12)
                     }
                 }
+
+                RecoveryChartCard(title: "Blood Oxygen (7d)", colorScheme: colorScheme) {
+                    if #available(iOS 16.0, *) {
+                        Chart {
+                            ForEach(healthManager.bloodOxygenWeek.indices, id: \.self) { i in
+                                LineMark(
+                                    x: .value("Day", i),
+                                    y: .value("Oxygen", healthManager.bloodOxygenWeek[i])
+                                )
+                                PointMark(
+                                    x: .value("Day", i),
+                                    y: .value("Oxygen", healthManager.bloodOxygenWeek[i])
+                                )
+                            }
+                        }
+                        .chartYScale(domain: 90...100)
+                        .frame(height: 140)
+                    } else {
+                        Text("Available on iOS 16+")
+                            .foregroundColor(.secondary)
+                            .frame(height: 150)
+                            .frame(maxWidth: .infinity)
+                            .background(Color(.secondarySystemBackground))
+                            .cornerRadius(12)
+                    }
+                }
             }
             .padding(.vertical)
         }


### PR DESCRIPTION
## Summary
- track blood oxygen in `HealthManager`
- fetch blood oxygen data from HealthKit and store weekly values
- expose blood oxygen metrics to Firestore save function
- update HealthKit permissions for oxygen data
- display a new "Blood Oxygen (7d)" chart card on the Recovery screen

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project AthleteHub.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68672731ede4832b972956f68ea413e2