### PR TITLE
Add meal-based manual entry and reset buttons

### DIFF
--- a/AthleteHub/AthleteHub/NutritionView.swift
+++ b/AthleteHub/AthleteHub/NutritionView.swift
@@ -471,7 +471,8 @@ struct NutritionView: View {
     struct ManualNutritionEntryView: View {
         @Environment(\.presentationMode) var presentationMode
         @EnvironmentObject var userProfile: UserProfile
-        
+
+        @State private var mealName: String = ""
         @State private var calories: String = ""
         @State private var protein: String = ""
         @State private var carbs: String = ""
@@ -483,6 +484,9 @@ struct NutritionView: View {
             NavigationView {
                 ScrollView {
                     VStack(spacing: 16) {
+                        TextField("Meal Name", text: $mealName)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+
                         Group {
                             TextField("Calories", text: $calories)
                             TextField("Protein (g)", text: $protein)
@@ -493,9 +497,15 @@ struct NutritionView: View {
                         }
                         .keyboardType(.decimalPad)
                         .textFieldStyle(RoundedBorderTextFieldStyle())
-                        
-                        Button(action: saveEntry) {
-                            Text("Save")
+
+                        HStack {
+                            Button("Reset") { resetFields() }
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.gray.opacity(0.2))
+                                .cornerRadius(12)
+
+                            Button("Add Meal") { addMeal() }
                                 .frame(maxWidth: .infinity)
                                 .padding()
                                 .background(Color.green)
@@ -506,7 +516,7 @@ struct NutritionView: View {
                     }
                     .padding()
                 }
-                .navigationTitle("Manual Nutrition Entry")
+                .navigationTitle("Add Meal")
                 .navigationBarItems(trailing: Button("Cancel") {
                     presentationMode.wrappedValue.dismiss()
                 })
@@ -520,15 +530,34 @@ struct NutritionView: View {
                 }
             }
         }
-        
-        private func saveEntry() {
-            userProfile.caloriesConsumed = calories
-            userProfile.proteinIntake = protein
-            userProfile.carbsIntake = carbs
-            userProfile.fatIntake = fat
-            userProfile.waterIntake = water
-            userProfile.fiberIntake = fiber
-            userProfile.loadFromFirestore()
+
+        private func resetFields() {
+            mealName = ""
+            calories = ""
+            protein = ""
+            carbs = ""
+            fat = ""
+            water = ""
+            fiber = ""
+        }
+
+        private func addMeal() {
+            func add(_ current: String?, with value: String) -> String {
+                let total = (Double(current ?? "0") ?? 0) + (Double(value) ?? 0)
+                return String(format: "%.0f", total)
+            }
+
+            userProfile.caloriesConsumed = add(userProfile.caloriesConsumed, with: calories)
+            userProfile.proteinIntake = add(userProfile.proteinIntake, with: protein)
+            userProfile.carbsIntake = add(userProfile.carbsIntake, with: carbs)
+            userProfile.fatIntake = add(userProfile.fatIntake, with: fat)
+            userProfile.waterIntake = add(userProfile.waterIntake, with: water)
+            userProfile.fiberIntake = add(userProfile.fiberIntake, with: fiber)
+
+            if !mealName.isEmpty {
+                userProfile.meals.append(mealName)
+            }
+
             presentationMode.wrappedValue.dismiss()
         }
     }

--- a/AthleteHub/AthleteHub/RecoveryView.swift
+++ b/AthleteHub/AthleteHub/RecoveryView.swift
@@ -710,8 +710,9 @@ struct ManualRecoveryEntryView: View {
             }
             .navigationTitle("Manual Recovery Entry")
             .navigationBarItems(
-                leading: Button("Cancel") {
-                    presentationMode.wrappedValue.dismiss()
+                leading: HStack {
+                    Button("Cancel") { presentationMode.wrappedValue.dismiss() }
+                    Button("Reset") { resetFields() }
                 },
                 trailing: Button("Save") {
                     healthManager.saveManualRecoveryEntry(
@@ -725,6 +726,14 @@ struct ManualRecoveryEntryView: View {
                 }
             )
         }
+    }
+
+    private func resetFields() {
+        sleepDuration = 0
+        sleepScore = 0
+        hrv = 0
+        restingHR = 0
+        stressLevel = 0
     }
 }
 

--- a/AthleteHub/AthleteHub/TrainingView.swift
+++ b/AthleteHub/AthleteHub/TrainingView.swift
@@ -400,7 +400,7 @@ struct ManualTrainingEntryView: View {
     
     @EnvironmentObject var healthManager: HealthManager
     @Environment(\.presentationMode) var presentationMode
-    
+
     @State private var calories: String = ""
     @State private var steps: String = ""
     @State private var minutes: String = ""
@@ -413,56 +413,52 @@ struct ManualTrainingEntryView: View {
                 Section(header: Text("Enter Training Data")) {
                     TextField("Calories (kcal)", text: $calories)
                         .keyboardType(.decimalPad)
-                    
+
                     TextField("Steps", text: $steps)
                         .keyboardType(.numberPad)
-                    
+
                     TextField("Exercise Minutes", text: $minutes)
                         .keyboardType(.decimalPad)
-                    
+
                     TextField("Distance (km)", text: $distance)
                         .keyboardType(.decimalPad)
                 }
-                Button("Save") {
-                    if let calories = Double(calories) {
-                        healthManager.totalCalories = calories
-                    }
-                    if let steps = Double(steps) {
-                        healthManager.steps = steps
-                    }
-                    if let minutes = Double(minutes) {
-                        healthManager.exerciseMinutes = minutes
-                    }
-                    if let distance = Double(distance) {
-                        healthManager.distance = distance
-                    }
-                    
-                    if let userId = Auth.auth().currentUser?.uid {
-                        healthManager.saveDailyMetricsToFirestore(userId: userId)
-                    }
-                    
-                    presentationMode.wrappedValue.dismiss()
-                }
-                .navigationTitle("Manual Entry")
-                .navigationBarItems(trailing: Button("Save") {
-                    if let cal = Double(calories) {
-                        healthManager.activeCalories = cal
-                        healthManager.totalCalories = cal + (healthManager.totalCalories ?? 0 - (healthManager.activeCalories ?? 0))
-                    }
-                    if let st = Double(steps) {
-                        healthManager.steps = st
-                    }
-                    if let min = Double(minutes) {
-                        healthManager.exerciseMinutes = min
-                    }
-                    if let dist = Double(distance) {
-                        healthManager.distance = dist
-                    }
-                    
-                    presentationMode.wrappedValue.dismiss()
-                })
             }
+            .navigationTitle("Manual Entry")
+            .navigationBarItems(
+                leading: Button("Reset") { resetFields() },
+                trailing: Button("Save") { saveEntry() }
+            )
         }
+    }
+
+    private func resetFields() {
+        calories = ""
+        steps = ""
+        minutes = ""
+        distance = ""
+    }
+
+    private func saveEntry() {
+        if let cal = Double(calories) {
+            healthManager.activeCalories = cal
+            healthManager.totalCalories = cal + (healthManager.totalCalories ?? 0 - (healthManager.activeCalories ?? 0))
+        }
+        if let st = Double(steps) {
+            healthManager.steps = st
+        }
+        if let min = Double(minutes) {
+            healthManager.exerciseMinutes = min
+        }
+        if let dist = Double(distance) {
+            healthManager.distance = dist
+        }
+
+        if let userId = Auth.auth().currentUser?.uid {
+            healthManager.saveDailyMetricsToFirestore(userId: userId)
+        }
+
+        presentationMode.wrappedValue.dismiss()
     }
 }
 


### PR DESCRIPTION
## Summary
- redesign manual nutrition entry as an "Add Meal" form
- add reset button to all manual entry screens

## Testing
- `swift build` *(fails: Could not find Package.swift)*


------
https://chatgpt.com/codex/tasks/task_e_686731b0df38832b8544cc87cdba7651