### PR TITLE
Add quick add sheets for nutrition metrics

### DIFF
--- a/AthleteHub/AthleteHub/AppData.swift
+++ b/AthleteHub/AthleteHub/AppData.swift
@@ -128,6 +128,22 @@ class UserProfile: ObservableObject {
     @Published var trainingLog: [String] = []
     @Published var meals: [String] = []
     @Published var recoveryActivities: [String] = []
+
+    private let lastResetKey = "lastNutritionResetDate"
+
+    /// Reset daily nutrition fields if the stored date is not today.
+    func resetDailyNutritionIfNeeded() {
+        let last = UserDefaults.standard.object(forKey: lastResetKey) as? Date ?? .distantPast
+        if !Calendar.current.isDateInToday(last) {
+            caloriesConsumed = "0"
+            proteinIntake = "0"
+            carbsIntake = "0"
+            fatIntake = "0"
+            waterIntake = "0"
+            fiberIntake = "0"
+            UserDefaults.standard.set(Date(), forKey: lastResetKey)
+        }
+    }
     
     // MARK: - Percentage Calculations
     private func recalcCaloriesPercentage() {
@@ -237,6 +253,7 @@ class UserProfile: ObservableObject {
                     self.waterStatus = data["waterStatus"] as? String
                     self.waterDescription = data["waterDescription"] as? String
 
+                    self.resetDailyNutritionIfNeeded()
                 }
             }
         }


### PR DESCRIPTION
## Summary
- support per-metric quick add sheets in NutritionView
- show current value and use Stepper to add more
- taping a ring or water card opens the dial sheet

## Testing
- `swift --version`
- `swiftc -o /tmp/testcomp AthleteHub/AthleteHub/NutritionView.swift` *(fails: no SwiftUI module)*

------
https://chatgpt.com/codex/tasks/task_e_68689a87db34832bab6063db1ec58db6