### PR TITLE
Store daily metrics in nested folders

### DIFF
--- a/AthleteHub/AthleteHub/AppData.swift
+++ b/AthleteHub/AthleteHub/AppData.swift
@@ -132,17 +132,24 @@ class UserProfile: ObservableObject {
     private let lastResetKey = "lastNutritionResetDate"
 
     /// Reset daily nutrition fields if the stored date is not today.
+    ///
+    /// This ensures metrics such as calories or water intake start at zero each
+    /// day while persistent attributes like height, weight or age remain
+    /// unchanged. The logged meals array is also cleared so that meals do not
+    /// carry over into the following day.
     func resetDailyNutritionIfNeeded() {
         let last = UserDefaults.standard.object(forKey: lastResetKey) as? Date ?? .distantPast
-        if !Calendar.current.isDateInToday(last) {
-            caloriesConsumed = "0"
-            proteinIntake = "0"
-            carbsIntake = "0"
-            fatIntake = "0"
-            waterIntake = "0"
-            fiberIntake = "0"
-            UserDefaults.standard.set(Date(), forKey: lastResetKey)
-        }
+        guard !Calendar.current.isDateInToday(last) else { return }
+
+        caloriesConsumed = "0"
+        proteinIntake = "0"
+        carbsIntake = "0"
+        fatIntake = "0"
+        waterIntake = "0"
+        fiberIntake = "0"
+        meals.removeAll()
+
+        UserDefaults.standard.set(Date(), forKey: lastResetKey)
     }
     
     // MARK: - Percentage Calculations

--- a/AthleteHub/AthleteHub/HealthManager.swift
+++ b/AthleteHub/AthleteHub/HealthManager.swift
@@ -241,48 +241,68 @@ class HealthManager: ObservableObject {
         let dateString = formatter.string(from: today)
 
         let recovery = calculateOverallRecoveryScore()
+        let trainingScore = calculateOverallTrainingScore()
 
-        let metrics: [String: Any] = [
+        let dayDoc = db.collection("users")
+            .document(userId)
+            .collection("days")
+            .document(dateString)
+
+        dayDoc.setData([
             "date": dateString,
+            "trainingScore": trainingScore,
+            "recoveryScore": recovery
+        ], merge: true) { error in
+            if let error = error {
+                print("❌ Error saving day summary: \(error.localizedDescription)")
+            } else {
+                print("✅ Saved summary for \(dateString)")
+                self.updateDailyTrainingScore(Int(trainingScore))
+            }
+        }
+
+        let trainingMetrics: [String: Any] = [
             "activeCalories": activeCalories ?? 0,
             "totalCalories": totalCalories ?? 0,
             "exerciseMinutes": exerciseMinutes ?? 0,
             "distance": distance ?? 0,
-            "restingHeartRate": restingHeartRate ?? 0,
-            "hrv": hrv ?? 0,
             "steps": steps ?? 0,
             "vo2Max": vo2Max ?? 0,
             "bodyMass": bodyMass ?? 0,
             "height": height ?? 0,
-            "waterIntake": waterIntake ?? 0,
-            "caloriesConsumed": caloriesConsumed ?? 0,
-            "proteinIntake": proteinIntake ?? 0,
-            "carbsIntake": carbsIntake ?? 0,
-            "fatIntake": fatIntake ?? 0,
-            "fiberIntake": fiberIntake ?? 0,
-            "trainingScore": calculateOverallTrainingScore(),
             "weeklyDistance": weeklyDistance ?? 0,
-            "weeklyHours": weeklyHours ?? 0,
+            "weeklyHours": weeklyHours ?? 0
+        ]
+
+        dayDoc.collection("training").document("metrics")
+            .setData(trainingMetrics, merge: true)
+
+        let recoveryMetrics: [String: Any] = [
+            "restingHeartRate": restingHeartRate ?? 0,
+            "hrv": hrv ?? 0,
             "sleepDuration": sleepDuration ?? 0,
             "sleepQuality": sleepQuality,
             "sleepQualityScore": sleepQualityScore ?? 0,
             "stressLevel": stressLevel ?? 0,
-            "recoveryScore": recovery,
             "hrvWeek": hrvWeek,
             "bloodOxygen": bloodOxygen ?? 0,
             "bloodOxygenWeek": bloodOxygenWeek
         ]
 
-        db.collection("users").document(userId)
-            .collection("dailyMetrics").document(dateString)
-            .setData(metrics, merge: true) { error in
-                if let error = error {
-                    print("❌ Error saving daily metrics: \(error.localizedDescription)")
-                } else {
-                    print("✅ Saved metrics for \(dateString)")
-                    self.updateDailyTrainingScore(Int(self.calculateOverallTrainingScore()))
-                }
-            }
+        dayDoc.collection("recovery").document("metrics")
+            .setData(recoveryMetrics, merge: true)
+
+        let nutritionMetrics: [String: Any] = [
+            "waterIntake": waterIntake ?? 0,
+            "caloriesConsumed": caloriesConsumed ?? 0,
+            "proteinIntake": proteinIntake ?? 0,
+            "carbsIntake": carbsIntake ?? 0,
+            "fatIntake": fatIntake ?? 0,
+            "fiberIntake": fiberIntake ?? 0
+        ]
+
+        dayDoc.collection("nutrition").document("metrics")
+            .setData(nutritionMetrics, merge: true)
     }
     
     
@@ -924,7 +944,7 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
 
         db.collection("users")
             .document(uid)
-            .collection("dailyMetrics")
+            .collection("days")
             .whereField("date", isGreaterThanOrEqualTo: startString)
             .order(by: "date", descending: false)
             .addSnapshotListener { snapshot, _ in

--- a/AthleteHub/AthleteHub/NutritionView.swift
+++ b/AthleteHub/AthleteHub/NutritionView.swift
@@ -184,6 +184,9 @@ struct NutritionView: View {
                     .environmentObject(userProfile)
                     .environmentObject(healthManager)
             }
+            .onAppear {
+                userProfile.resetDailyNutritionIfNeeded()
+            }
         }
     }
     


### PR DESCRIPTION
## Summary
- group training, recovery, and nutrition metrics under each day
- fetch training scores from new `days` collection

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6868ac071224832ba35f07a2a9cd1dc9