### PR TITLE
Add profile subcollection

### DIFF
--- a/AthleteHub/AthleteHub/AppData.swift
+++ b/AthleteHub/AthleteHub/AppData.swift
@@ -132,17 +132,24 @@ class UserProfile: ObservableObject {
     private let lastResetKey = "lastNutritionResetDate"
 
     /// Reset daily nutrition fields if the stored date is not today.
+    ///
+    /// This ensures metrics such as calories or water intake start at zero each
+    /// day while persistent attributes like height, weight or age remain
+    /// unchanged. The logged meals array is also cleared so that meals do not
+    /// carry over into the following day.
     func resetDailyNutritionIfNeeded() {
         let last = UserDefaults.standard.object(forKey: lastResetKey) as? Date ?? .distantPast
-        if !Calendar.current.isDateInToday(last) {
-            caloriesConsumed = "0"
-            proteinIntake = "0"
-            carbsIntake = "0"
-            fatIntake = "0"
-            waterIntake = "0"
-            fiberIntake = "0"
-            UserDefaults.standard.set(Date(), forKey: lastResetKey)
-        }
+        guard !Calendar.current.isDateInToday(last) else { return }
+
+        caloriesConsumed = "0"
+        proteinIntake = "0"
+        carbsIntake = "0"
+        fatIntake = "0"
+        waterIntake = "0"
+        fiberIntake = "0"
+        meals.removeAll()
+
+        UserDefaults.standard.set(Date(), forKey: lastResetKey)
     }
     
     // MARK: - Percentage Calculations
@@ -189,13 +196,16 @@ class UserProfile: ObservableObject {
     }
     
     // MARK: - Firestore Integration
+    /// Load persistent profile data and nutrition goals from Firestore.
     func loadFromFirestore() {
         guard let currentUser = Auth.auth().currentUser else { return }
         self.uid = currentUser.uid
         self.email = currentUser.email ?? ""
-        
+
         let db = Firestore.firestore()
-        db.collection("users").document(uid).getDocument { snapshot, error in
+        let profileRef = db.collection("users").document(uid).collection("profile")
+
+        profileRef.document("info").getDocument { snapshot, _ in
             if let data = snapshot?.data() {
                 DispatchQueue.main.async {
                     self.name = data["name"] as? String ?? self.name
@@ -206,56 +216,65 @@ class UserProfile: ObservableObject {
                     self.height = data["height"] as? Double ?? self.height
                     self.weight = data["weight"] as? Double ?? self.weight
                     self.age = data["age"] as? Int ?? self.age
-                    
-                    self.sleepDuration = data["sleepDuration"] as? String
-                    self.sleepDurationStatus = data["sleepDurationStatus"] as? String
-                    self.sleepDurationDescription = data["sleepDurationDescription"] as? String
-                    self.sleepQuality = data["sleepQuality"] as? String
-                    self.sleepQualityStatus = data["sleepQualityStatus"] as? String
-                    self.sleepQualityDescription = data["sleepQualityDescription"] as? String
-                    self.stressLevel = data["stressLevel"] as? String
-                    self.stressLevelStatus = data["stressLevelStatus"] as? String
-                    self.stressLevelDescription = data["stressLevelDescription"] as? String
-                    self.restingHeartRate = data["restingHeartRate"] as? String
-                    self.restingHeartRateStatus = data["restingHeartRateStatus"] as? String
-                    self.restingHeartRateDescription = data["restingHeartRateDescription"] as? String
-                    self.hrv = data["hrv"] as? String
-                    self.hrvStatus = data["hrvStatus"] as? String
-                    self.hrvDescription = data["hrvDescription"] as? String
-                    self.overallRecoveryScore = data["overallRecoveryScore"] as? String
-                    self.overallRecoveryStatus = data["overallRecoveryStatus"] as? String
-                    self.overallRecoveryDescription = data["overallRecoveryDescription"] as? String
-                    self.recoveryTrendsAvailable = data["recoveryTrendsAvailable"] as? Bool ?? false
-                    self.sleepPhaseAnalysisAvailable = data["sleepPhaseAnalysisAvailable"] as? Bool ?? false
-                    
-                    self.caloriesConsumed = data["caloriesConsumed"] as? String
-                    self.caloriesGoal = data["caloriesGoal"] as? String
-                    self.caloriesStatus = data["caloriesStatus"] as? String
-                    self.caloriesDescription = data["caloriesDescription"] as? String
-                    
-                    self.proteinIntake = data["proteinIntake"] as? String
-                    self.proteinGoal = data["proteinGoal"] as? String
-                    self.proteinStatus = data["proteinStatus"] as? String
-                    self.proteinDescription = data["proteinDescription"] as? String
-                    
-                    self.carbsIntake = data["carbsIntake"] as? String
-                    self.carbsGoal = data["carbsGoal"] as? String
-                    self.carbsStatus = data["carbsStatus"] as? String
-                    self.carbsDescription = data["carbsDescription"] as? String
-                    
-                    self.fatIntake = data["fatIntake"] as? String
-                    self.fatGoal = data["fatGoal"] as? String
-                    self.fatStatus = data["fatStatus"] as? String
-                    self.fatDescription = data["fatDescription"] as? String
-                    
-                    self.waterIntake = data["waterIntake"] as? String
-                    self.waterGoal = data["waterGoal"] as? String
-                    self.waterStatus = data["waterStatus"] as? String
-                    self.waterDescription = data["waterDescription"] as? String
-
-                    self.resetDailyNutritionIfNeeded()
                 }
             }
         }
+
+        profileRef.document("goals").getDocument { snapshot, _ in
+            if let data = snapshot?.data() {
+                DispatchQueue.main.async {
+                    self.caloriesGoal = data["caloriesGoal"] as? String ?? self.caloriesGoal
+                    self.proteinGoal = data["proteinGoal"] as? String ?? self.proteinGoal
+                    self.carbsGoal = data["carbsGoal"] as? String ?? self.carbsGoal
+                    self.fatGoal = data["fatGoal"] as? String ?? self.fatGoal
+                    self.waterGoal = data["waterGoal"] as? String ?? self.waterGoal
+                    self.fiberGoal = data["fiberGoal"] as? String ?? self.fiberGoal
+                }
+            }
+        }
+
+        resetDailyNutritionIfNeeded()
+    }
+
+    /// Persist core profile fields to Firestore under `profile/info`.
+    func saveToFirestore() {
+        guard !uid.isEmpty else { return }
+        let data: [String: Any] = [
+            "name": name,
+            "role": role,
+            "phone": phone,
+            "birthDate": birthDate,
+            "sex": sex,
+            "height": height,
+            "weight": weight,
+            "age": age
+        ]
+
+        Firestore.firestore()
+            .collection("users")
+            .document(uid)
+            .collection("profile")
+            .document("info")
+            .setData(data, merge: true)
+    }
+
+    /// Save all nutrition goal values under `profile/goals`.
+    func saveGoalsToFirestore() {
+        guard !uid.isEmpty else { return }
+        let data: [String: Any] = [
+            "caloriesGoal": caloriesGoal ?? "",
+            "proteinGoal": proteinGoal ?? "",
+            "carbsGoal": carbsGoal ?? "",
+            "fatGoal": fatGoal ?? "",
+            "waterGoal": waterGoal ?? "",
+            "fiberGoal": fiberGoal ?? ""
+        ]
+
+        Firestore.firestore()
+            .collection("users")
+            .document(uid)
+            .collection("profile")
+            .document("goals")
+            .setData(data, merge: true)
     }
 }

--- a/AthleteHub/AthleteHub/NutritionView.swift
+++ b/AthleteHub/AthleteHub/NutritionView.swift
@@ -184,6 +184,9 @@ struct NutritionView: View {
                     .environmentObject(userProfile)
                     .environmentObject(healthManager)
             }
+            .onAppear {
+                userProfile.resetDailyNutritionIfNeeded()
+            }
         }
     }
     
@@ -732,7 +735,7 @@ struct NutritionView: View {
                     userProfile.fatGoal = fatGoal
                     userProfile.waterGoal = waterGoal
                     userProfile.fiberGoal = fiberGoal
-                    userProfile.loadFromFirestore()
+                    userProfile.saveGoalsToFirestore()
                     presentationMode.wrappedValue.dismiss()
                 })
                 .onAppear {


### PR DESCRIPTION
## Summary
- fetch and persist permanent user info and goals in `profile` subcollection
- store training, recovery and nutrition metrics only under each day
- update nutrition goal editing to save goals to Firestore
- sync daily goals from Firestore when they change

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project AthleteHub/AthleteHub.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ac071224832ba35f07a2a9cd1dc9