### PR TITLE
Fix nutrition ring progress updates

### DIFF
--- a/AthleteHub/AthleteHub/NutritionView.swift
+++ b/AthleteHub/AthleteHub/NutritionView.swift
@@ -272,6 +272,11 @@ struct NutritionView: View {
                     animatedProgress = progress
                 }
             }
+            .onChange(of: percentage) { _ in
+                withAnimation(.easeOut(duration: 1.2)) {
+                    animatedProgress = progress
+                }
+            }
             .onTapGesture { onTap() }
         }
     }
@@ -353,6 +358,11 @@ struct NutritionView: View {
             .cornerRadius(16)
             .shadow(color: Color.green.opacity(0.3), radius: 8, x: 0, y: 4)
             .onAppear {
+                withAnimation(.easeOut(duration: 1.2)) {
+                    animatedProgress = progress
+                }
+            }
+            .onChange(of: percentage) { _ in
                 withAnimation(.easeOut(duration: 1.2)) {
                     animatedProgress = progress
                 }


### PR DESCRIPTION
## Summary
- keep nutrition metric rings in sync with goal progress
- sync water intake ring with goal progress

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868cf7909d4832baa1a5f31dc687170