### PR TITLE
Ensure nutrition rings appear on data changes

### DIFF
--- a/AthleteHub/AthleteHub/NutritionView.swift
+++ b/AthleteHub/AthleteHub/NutritionView.swift
@@ -219,6 +219,12 @@ struct NutritionView: View {
             default:       return .green
             }
         }
+
+        private func animateProgress() {
+            withAnimation(.easeOut(duration: 1.2)) {
+                animatedProgress = progress
+            }
+        }
         
         var body: some View {
             VStack(spacing: 16) {
@@ -267,11 +273,8 @@ struct NutritionView: View {
                         : Color(.systemBackground))
             .cornerRadius(16)
             .shadow(color: Color.green.opacity(0.3), radius: 8, x: 0, y: 4)
-            .onAppear {
-                withAnimation(.easeOut(duration: 1.2)) {
-                    animatedProgress = progress
-                }
-            }
+            .onAppear { animateProgress() }
+            .onChange(of: progress) { _ in animateProgress() }
             .onTapGesture { onTap() }
         }
     }
@@ -303,6 +306,12 @@ struct NutritionView: View {
         }
         private var remaining: Double {
             max(numericGoal - numericIntake, 0)
+        }
+
+        private func animateProgress() {
+            withAnimation(.easeOut(duration: 1.2)) {
+                animatedProgress = progress
+            }
         }
         
         var body: some View {
@@ -352,11 +361,8 @@ struct NutritionView: View {
                         : Color(.systemBackground))
             .cornerRadius(16)
             .shadow(color: Color.green.opacity(0.3), radius: 8, x: 0, y: 4)
-            .onAppear {
-                withAnimation(.easeOut(duration: 1.2)) {
-                    animatedProgress = progress
-                }
-            }
+            .onAppear { animateProgress() }
+            .onChange(of: progress) { _ in animateProgress() }
             .onTapGesture { onTap() }
         }
     }


### PR DESCRIPTION
## Summary
- keep progress rings in sync with new data by listening to progress changes
- trigger animations when water or nutrition metrics update

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868cf7909d4832baa1a5f31dc687170