### PR TITLE
Add training calendar view

### DIFF
--- a/AthleteHub/AthleteHub/AthleteHubApp.swift
+++ b/AthleteHub/AthleteHub/AthleteHubApp.swift
@@ -14,6 +14,7 @@ struct AthleteHubApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     @StateObject private var authViewModel = AuthViewModel()
     @StateObject private var healthManager = HealthManager()
+    @StateObject private var scheduleManager = TrainingScheduleManager()
     @State private var isLoading = true
 
     var body: some Scene {
@@ -32,6 +33,7 @@ struct AthleteHubApp: App {
                     .environmentObject(authViewModel)
                     .environmentObject(authViewModel.userProfile)
                     .environmentObject(healthManager)
+                    .environmentObject(scheduleManager)
             }
         }
     }

--- a/AthleteHub/AthleteHub/TrainingCalendarView.swift
+++ b/AthleteHub/AthleteHub/TrainingCalendarView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+struct TrainingCalendarView: View {
+    @EnvironmentObject var scheduleManager: TrainingScheduleManager
+    @State private var selectedDate = Date()
+    @State private var showingAddSheet = false
+
+    private var dayTrainings: [ScheduledTraining] {
+        scheduleManager.trainings.filter { Calendar.current.isDate($0.date, inSameDayAs: selectedDate) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            DatePicker("", selection: $selectedDate, displayedComponents: .date)
+                .datePickerStyle(.graphical)
+
+            if dayTrainings.isEmpty {
+                Text("No trainings scheduled")
+                    .foregroundColor(.secondary)
+            } else {
+                ForEach(dayTrainings) { training in
+                    HStack {
+                        Text(training.title)
+                        Spacer()
+                        Text(training.date, style: .time)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(8)
+                    .background(Color(.secondarySystemBackground))
+                    .cornerRadius(8)
+                }
+                .onDelete(perform: delete)
+            }
+
+            Button(action: { showingAddSheet = true }) {
+                Label("Add Training", systemImage: "plus")
+            }
+            .sheet(isPresented: $showingAddSheet) {
+                AddTrainingView(date: selectedDate)
+                    .environmentObject(scheduleManager)
+            }
+        }
+        .padding()
+    }
+
+    private func delete(at offsets: IndexSet) {
+        let ids = offsets.map { dayTrainings[$0].id }
+        scheduleManager.trainings.removeAll { ids.contains($0.id) }
+    }
+}
+
+struct AddTrainingView: View {
+    @EnvironmentObject var scheduleManager: TrainingScheduleManager
+    @Environment(\.dismiss) var dismiss
+    @State var date: Date
+    @State private var time = Date()
+    @State private var title = ""
+
+    var body: some View {
+        NavigationView {
+            Form {
+                TextField("Title", text: $title)
+                DatePicker("Date", selection: $date, displayedComponents: .date)
+                DatePicker("Time", selection: $time, displayedComponents: .hourAndMinute)
+            }
+            .navigationTitle("New Training")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Save") {
+                        var comps = Calendar.current.dateComponents([.year, .month, .day], from: date)
+                        let t = Calendar.current.dateComponents([.hour, .minute], from: time)
+                        comps.hour = t.hour
+                        comps.minute = t.minute
+                        let combined = Calendar.current.date(from: comps) ?? date
+                        scheduleManager.addTraining(date: combined, title: title)
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AthleteHub/AthleteHub/TrainingScheduleManager.swift
+++ b/AthleteHub/AthleteHub/TrainingScheduleManager.swift
@@ -1,0 +1,39 @@
+import Foundation
+import SwiftUI
+
+struct ScheduledTraining: Identifiable, Codable, Equatable {
+    var id = UUID()
+    var date: Date
+    var title: String
+}
+
+class TrainingScheduleManager: ObservableObject {
+    @Published var trainings: [ScheduledTraining] = []
+
+    init() {
+        load()
+    }
+
+    func addTraining(date: Date, title: String) {
+        trainings.append(ScheduledTraining(date: date, title: title))
+        save()
+    }
+
+    func removeTraining(at offsets: IndexSet) {
+        trainings.remove(atOffsets: offsets)
+        save()
+    }
+
+    private func load() {
+        if let data = UserDefaults.standard.data(forKey: "scheduledTrainings"),
+           let decoded = try? JSONDecoder().decode([ScheduledTraining].self, from: data) {
+            trainings = decoded
+        }
+    }
+
+    private func save() {
+        if let data = try? JSONEncoder().encode(trainings) {
+            UserDefaults.standard.set(data, forKey: "scheduledTrainings")
+        }
+    }
+}

--- a/AthleteHub/AthleteHub/TrainingView.swift
+++ b/AthleteHub/AthleteHub/TrainingView.swift
@@ -9,6 +9,7 @@ import HealthKit
 struct TrainingView: View {
     @Environment(\.colorScheme) var colorScheme
     @EnvironmentObject var healthManager: HealthManager
+    @EnvironmentObject var scheduleManager: TrainingScheduleManager
     @State private var showingSetGoals = false
     @State private var showingManualEntry = false
     
@@ -93,8 +94,10 @@ struct TrainingView: View {
                 .padding(.horizontal)
 
                 RecentWorkoutsCard(healthManager: healthManager, colorScheme: colorScheme)
-                
+
                 TrainingScoreTrendCard(healthManager: healthManager)
+
+                TrainingCalendarView()
             }
             .padding(.vertical)
         }


### PR DESCRIPTION
## Summary
- track scheduled trainings in new `TrainingScheduleManager`
- show graphical calendar with upcoming trainings
- inject schedule manager into the app environment
- display the calendar in Training view

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a39e91624832ba5d0ac14693cdc69