### PR TITLE
Add card styling and editing for training calendar

### DIFF
--- a/AthleteHub/AthleteHub/TrainingCalendarView.swift
+++ b/AthleteHub/AthleteHub/TrainingCalendarView.swift
@@ -2,17 +2,30 @@ import SwiftUI
 
 struct TrainingCalendarView: View {
     @EnvironmentObject var scheduleManager: TrainingScheduleManager
+    @Environment(\.colorScheme) var colorScheme
     @State private var selectedDate = Date()
     @State private var showingAddSheet = false
+    @State private var trainingToEdit: ScheduledTraining?
 
     private var dayTrainings: [ScheduledTraining] {
         scheduleManager.trainings.filter { Calendar.current.isDate($0.date, inSameDayAs: selectedDate) }
+    }
+
+    private var weekTrainings: [Date: [ScheduledTraining]] {
+        let calendar = Calendar.current
+        let startOfWeek = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: selectedDate)) ?? selectedDate
+        let endOfWeek = calendar.date(byAdding: .day, value: 7, to: startOfWeek) ?? startOfWeek
+        let trainings = scheduleManager.trainings.filter { $0.date >= startOfWeek && $0.date < endOfWeek }
+        return Dictionary(grouping: trainings) { calendar.startOfDay(for: $0.date) }
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             DatePicker("", selection: $selectedDate, displayedComponents: .date)
                 .datePickerStyle(.graphical)
+                .padding(8)
+                .background(Color.yellow.opacity(0.3))
+                .cornerRadius(12)
 
             if dayTrainings.isEmpty {
                 Text("No trainings scheduled")
@@ -28,6 +41,9 @@ struct TrainingCalendarView: View {
                     .padding(8)
                     .background(Color(.secondarySystemBackground))
                     .cornerRadius(8)
+                    .onTapGesture {
+                        trainingToEdit = training
+                    }
                 }
                 .onDelete(perform: delete)
             }
@@ -39,7 +55,46 @@ struct TrainingCalendarView: View {
                 AddTrainingView(date: selectedDate)
                     .environmentObject(scheduleManager)
             }
+            .sheet(item: $trainingToEdit) { training in
+                AddTrainingView(training: training)
+                    .environmentObject(scheduleManager)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Week Overview")
+                    .font(.headline)
+
+                if weekTrainings.isEmpty {
+                    Text("No trainings this week")
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(weekTrainings.keys.sorted(), id: \.self) { day in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(day, style: .date)
+                                .fontWeight(.semibold)
+                            ForEach(weekTrainings[day] ?? []) { training in
+                                HStack {
+                                    Text(training.title)
+                                    Spacer()
+                                    Text(training.date, style: .time)
+                                        .foregroundColor(.secondary)
+                                }
+                                .onTapGesture {
+                                    trainingToEdit = training
+                                }
+                            }
+                        }
+                        .padding(8)
+                        .background(Color(.secondarySystemBackground))
+                        .cornerRadius(8)
+                    }
+                }
+            }
         }
+        .padding()
+        .background(colorScheme == .dark ? Color(.secondarySystemBackground) : Color.white)
+        .cornerRadius(20)
+        .shadow(color: Color.yellow.opacity(0.3), radius: 8, x: 0, y: 4)
         .padding()
     }
 
@@ -52,9 +107,17 @@ struct TrainingCalendarView: View {
 struct AddTrainingView: View {
     @EnvironmentObject var scheduleManager: TrainingScheduleManager
     @Environment(\.dismiss) var dismiss
-    @State var date: Date
-    @State private var time = Date()
-    @State private var title = ""
+    var training: ScheduledTraining?
+    @State private var date: Date
+    @State private var time: Date
+    @State private var title: String
+
+    init(training: ScheduledTraining? = nil, date: Date = Date()) {
+        self.training = training
+        _date = State(initialValue: training?.date ?? date)
+        _time = State(initialValue: training?.date ?? Date())
+        _title = State(initialValue: training?.title ?? "")
+    }
 
     var body: some View {
         NavigationView {
@@ -63,7 +126,7 @@ struct AddTrainingView: View {
                 DatePicker("Date", selection: $date, displayedComponents: .date)
                 DatePicker("Time", selection: $time, displayedComponents: .hourAndMinute)
             }
-            .navigationTitle("New Training")
+            .navigationTitle(training == nil ? "New Training" : "Edit Training")
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Cancel") { dismiss() }
@@ -75,7 +138,11 @@ struct AddTrainingView: View {
                         comps.hour = t.hour
                         comps.minute = t.minute
                         let combined = Calendar.current.date(from: comps) ?? date
-                        scheduleManager.addTraining(date: combined, title: title)
+                        if let training = training {
+                            scheduleManager.updateTraining(training, date: combined, title: title)
+                        } else {
+                            scheduleManager.addTraining(date: combined, title: title)
+                        }
                         dismiss()
                     }
                 }

--- a/AthleteHub/AthleteHub/TrainingScheduleManager.swift
+++ b/AthleteHub/AthleteHub/TrainingScheduleManager.swift
@@ -19,6 +19,14 @@ class TrainingScheduleManager: ObservableObject {
         save()
     }
 
+    func updateTraining(_ training: ScheduledTraining, date: Date, title: String) {
+        if let index = trainings.firstIndex(where: { $0.id == training.id }) {
+            trainings[index].date = date
+            trainings[index].title = title
+            save()
+        }
+    }
+
     func removeTraining(at offsets: IndexSet) {
         trainings.remove(atOffsets: offsets)
         save()


### PR DESCRIPTION
## Summary
- wrap the calendar and week overview in a card with a yellow shadow
- allow tapping a training session to edit it in place
- support updating scheduled trainings in TrainingScheduleManager

## Testing
- `swiftc AthleteHub/AthleteHub/TrainingScheduleManager.swift AthleteHub/AthleteHub/TrainingCalendarView.swift -o /tmp/test-app` *(fails: no such module 'SwiftUI')*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a50c566fc832bb172c7571499b6a3