### PR TITLE
Add coach role and dashboard

### DIFF
--- a/AthleteHub/AthleteHub/AthleteDetailView.swift
+++ b/AthleteHub/AthleteHub/AthleteDetailView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct AthleteDetailView: View {
+    let athleteId: String
+    @StateObject private var profile = UserProfile()
+
+    var body: some View {
+        DashboardView()
+            .environmentObject(profile)
+            .onAppear {
+                profile.uid = athleteId
+                profile.loadFromFirestore()
+            }
+    }
+}

--- a/AthleteHub/AthleteHub/AuthViewModel.swift
+++ b/AthleteHub/AthleteHub/AuthViewModel.swift
@@ -43,7 +43,7 @@ class AuthViewModel: ObservableObject {
         }
     }
 
-    func signUp(email: String, password: String, name: String, birthDate: String, sex: String, height: Double, weight: Double) {
+    func signUp(email: String, password: String, name: String, birthDate: String, sex: String, height: Double, weight: Double, role: String) {
         Auth.auth().createUser(withEmail: email, password: password) { result, error in
             if let error = error {
                 print("Error signing up: \(error.localizedDescription)")
@@ -56,6 +56,15 @@ class AuthViewModel: ObservableObject {
                 self.userProfile.sex = sex
                 self.userProfile.height = height
                 self.userProfile.weight = weight
+                self.userProfile.role = role
+
+                let db = Firestore.firestore()
+                db.collection("users").document(user.uid).setData([
+                    "email": email,
+                    "name": name,
+                    "role": role
+                ])
+
                 self.userProfile.saveToFirestore()
             }
         }

--- a/AthleteHub/AthleteHub/CoachDashboardView.swift
+++ b/AthleteHub/AthleteHub/CoachDashboardView.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+import FirebaseFirestore
+
+struct AthleteRef: Identifiable {
+    var id: String
+    var name: String
+}
+
+struct CoachDashboardView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @State private var searchName = ""
+    @State private var searchResults: [AthleteRef] = []
+    @State private var suggestedAthletes: [AthleteRef] = []
+    @State private var errorMessage: String?
+    @State private var athletes: [AthleteRef] = []
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                HStack {
+                    TextField("Athlete name", text: $searchName)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .onChange(of: searchName) { _ in searchForName() }
+                }
+                .padding()
+
+                if !searchResults.isEmpty {
+                    VStack(alignment: .leading) {
+                        Text("Results")
+                            .font(.headline)
+                        ForEach(searchResults) { result in
+                            HStack {
+                                Text(result.name)
+                                Spacer()
+                                Button("Add") { addFoundAthlete(result) }
+                            }
+                        }
+                    }
+                    .padding(.horizontal)
+                } else if !searchName.isEmpty {
+                    Text(errorMessage ?? "No athletes found").foregroundColor(.red)
+                        .padding(.horizontal)
+                } else if !suggestedAthletes.isEmpty {
+                    VStack(alignment: .leading) {
+                        Text("Suggested")
+                            .font(.headline)
+                        ForEach(suggestedAthletes) { suggestion in
+                            HStack {
+                                Text(suggestion.name)
+                                Spacer()
+                                Button("Add") { addFoundAthlete(suggestion) }
+                            }
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+
+                List(athletes) { athlete in
+                    NavigationLink(destination: AthleteDetailView(athleteId: athlete.id)) {
+                        Text(athlete.name)
+                    }
+                }
+                .listStyle(InsetGroupedListStyle())
+                .onAppear {
+                    loadAthletes()
+                    fetchSuggestedAthletes()
+                }
+            }
+            .navigationTitle("Coach Dashboard")
+        }
+    }
+
+    private func searchForName() {
+        let db = Firestore.firestore()
+        let trimmed = searchName.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            searchResults = []
+            return
+        }
+        db.collection("users")
+            .whereField("role", isEqualTo: "Athlete")
+            .order(by: "name")
+            .start(at: [trimmed])
+            .end(at: [trimmed + "\u{f8ff}"])
+            .limit(to: 10)
+            .getDocuments { snapshot, _ in
+                if let docs = snapshot?.documents, !docs.isEmpty {
+                    searchResults = docs.map { AthleteRef(id: $0.documentID, name: $0.data()["name"] as? String ?? "Athlete") }
+                    errorMessage = nil
+                } else {
+                    searchResults = []
+                    errorMessage = "No athletes found"
+                }
+            }
+    }
+
+    private func fetchSuggestedAthletes() {
+        let db = Firestore.firestore()
+        db.collection("users")
+            .whereField("role", isEqualTo: "Athlete")
+            .order(by: "name")
+            .limit(to: 5)
+            .getDocuments { snapshot, _ in
+                if let docs = snapshot?.documents {
+                    suggestedAthletes = docs.map { AthleteRef(id: $0.documentID, name: $0.data()["name"] as? String ?? "Athlete") }
+                }
+            }
+    }
+
+    private func addFoundAthlete(_ athlete: AthleteRef) {
+        let db = Firestore.firestore()
+        let coachId = authViewModel.userProfile.uid
+        guard !coachId.isEmpty else { return }
+        db.collection("coaches").document(coachId)
+            .collection("athletes").document(athlete.id)
+            .setData(["name": athlete.name]) { _ in
+                loadAthletes()
+                searchResults.removeAll { $0.id == athlete.id }
+                searchName = ""
+            }
+    }
+
+    private func loadAthletes() {
+        let db = Firestore.firestore()
+        guard !authViewModel.userProfile.uid.isEmpty else { return }
+        db.collection("coaches").document(authViewModel.userProfile.uid)
+            .collection("athletes").getDocuments { snapshot, _ in
+                if let docs = snapshot?.documents {
+                    athletes = docs.map { AthleteRef(id: $0.documentID, name: $0.data()["name"] as? String ?? "Athlete") }
+                }
+            }
+    }
+}

--- a/AthleteHub/AthleteHub/MainView.swift
+++ b/AthleteHub/AthleteHub/MainView.swift
@@ -8,12 +8,15 @@ struct MainView: View {
     var body: some View {
         Group {
             if authViewModel.user != nil {
-                TabView {
-                    DashboardView()
-                        .tabItem {
-                            Image(systemName: "house.fill")
-                            Text("Dashboard")
-                        }
+                if authViewModel.userProfile.role == "Coach" {
+                    CoachDashboardView()
+                } else {
+                    TabView {
+                        DashboardView()
+                            .tabItem {
+                                Image(systemName: "house.fill")
+                                Text("Dashboard")
+                            }
 
                     TrainingView()
                         .tabItem {
@@ -33,13 +36,14 @@ struct MainView: View {
                             Text("Recovery")
                         }
 
-                    ProfileView()
-                        .tabItem {
-                            Image(systemName: "person.crop.circle")
-                            Text("Profile")
-                        }
+                        ProfileView()
+                            .tabItem {
+                                Image(systemName: "person.crop.circle")
+                                Text("Profile")
+                            }
+                    }
+                    .edgesIgnoringSafeArea(.all)
                 }
-                .edgesIgnoringSafeArea(.all)
             } else {
                 LoginView()
             }

--- a/AthleteHub/AthleteHub/SignUpView.swift
+++ b/AthleteHub/AthleteHub/SignUpView.swift
@@ -8,12 +8,14 @@ struct SignUpView: View {
     @State private var name = ""
     @State private var birthDate = Date()
     @State private var sex = "Other"
+    @State private var role = "Athlete"
     @State private var height: Double = 170
     @State private var weight: Double = 70
     @State private var showAlert = false
     @State private var alertMessage = ""
 
     let sexOptions = ["Male", "Female", "Other"]
+    let roleOptions = ["Athlete", "Coach"]
 
     var body: some View {
         NavigationView {
@@ -52,6 +54,14 @@ struct SignUpView: View {
                         .pickerStyle(SegmentedPickerStyle())
                         .padding(.horizontal)
 
+                        Picker("Role", selection: $role) {
+                            ForEach(roleOptions, id: \.self) { option in
+                                Text(option)
+                            }
+                        }
+                        .pickerStyle(SegmentedPickerStyle())
+                        .padding(.horizontal)
+
                         VStack(alignment: .leading) {
                             Text("Height: \(Int(height)) cm")
                             Slider(value: $height, in: 100...250, step: 1)
@@ -68,7 +78,7 @@ struct SignUpView: View {
                     Button(action: {
                         if validateFields() {
                             let dobString = DateFormatter.localizedString(from: birthDate, dateStyle: .short, timeStyle: .none)
-                            authViewModel.signUp(email: email, password: password, name: name, birthDate: dobString, sex: sex, height: height, weight: weight)
+                            authViewModel.signUp(email: email, password: password, name: name, birthDate: dobString, sex: sex, height: height, weight: weight, role: role)
                             presentationMode.wrappedValue.dismiss()
                         }
                     }) {

--- a/AthleteHub/AthleteHub/UserSettingsFormView.swift
+++ b/AthleteHub/AthleteHub/UserSettingsFormView.swift
@@ -15,6 +15,8 @@ struct UserSettingsFormView: View {
     @State private var dob = Date()
     @State private var sexOptions = ["Male", "Female", "Other"]
     @State private var selectedSex = "Male"
+    @State private var roleOptions = ["Athlete", "Coach"]
+    @State private var selectedRole = "Athlete"
     @State private var height: Double = 170
     @State private var weight: Double = 70
     @State private var showingImagePicker = false
@@ -55,6 +57,11 @@ struct UserSettingsFormView: View {
                             Text(option)
                         }
                     }
+                    Picker("Role", selection: $selectedRole) {
+                        ForEach(roleOptions, id: \.self) { option in
+                            Text(option)
+                        }
+                    }
                     VStack(alignment: .leading) {
                         Text("Height: \(Int(height)) cm")
                         Slider(value: $height, in: 100...250, step: 1)
@@ -72,6 +79,7 @@ struct UserSettingsFormView: View {
                 userProfile.height = height
                 userProfile.weight = weight
                 userProfile.birthDate = DateFormatter.localizedString(from: dob, dateStyle: .short, timeStyle: .none)
+                userProfile.role = selectedRole
                 if let image = selectedImage {
                     userProfile.profileImage = image
                 }
@@ -80,6 +88,7 @@ struct UserSettingsFormView: View {
             .onAppear {
                 username = userProfile.name
                 selectedSex = userProfile.sex
+                selectedRole = userProfile.role
                 height = userProfile.height
                 weight = userProfile.weight
                 let formatter = DateFormatter()


### PR DESCRIPTION
## Summary
- add role field to sign up flow
- store the selected role in Firestore
- update user settings to edit the role
- show a coach dashboard when the user is a coach
- allow coaches to search and add athletes
- search now finds athletes by name and lists results
- search suggestions shown before typing
- fix missing `AthleteDetailView` by moving it to its own file

## Testing
- `swift test` *(fails: `Package.swift` missing)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686cb03231f0832b9f5a4c41596fea70