### PR TITLE
Use name as athlete profile identifier

### DIFF
--- a/AthleteHub/AthleteHub/AppData.swift
+++ b/AthleteHub/AthleteHub/AppData.swift
@@ -12,6 +12,9 @@ import FirebaseFirestore
 
 class UserProfile: ObservableObject {
     @Published var uid: String = ""
+    /// Identifier based on the user's display name. This mirrors the name field
+    /// so athletes can be referenced directly by a readable ID.
+    @Published var profileId: String = ""
     @Published var name: String = "Athlete"
     @Published var role: String = "Athlete"
     @Published var profileImage: UIImage? = nil
@@ -209,6 +212,7 @@ class UserProfile: ObservableObject {
             if let data = snapshot?.data() {
                 DispatchQueue.main.async {
                     self.name = data["name"] as? String ?? self.name
+                    self.profileId = data["profileId"] as? String ?? self.name
                     self.role = data["role"] as? String ?? self.role
                     self.phone = data["phone"] as? String ?? self.phone
                     self.birthDate = data["birthDate"] as? String ?? self.birthDate
@@ -241,6 +245,7 @@ class UserProfile: ObservableObject {
         guard !uid.isEmpty else { return }
         let data: [String: Any] = [
             "name": name,
+            "profileId": profileId,
             "role": role,
             "phone": phone,
             "birthDate": birthDate,
@@ -256,6 +261,12 @@ class UserProfile: ObservableObject {
             .collection("profile")
             .document("info")
             .setData(data, merge: true)
+
+        // Also mirror the profile identifier at the root user document
+        Firestore.firestore()
+            .collection("users")
+            .document(uid)
+            .setData(["profileId": profileId, "name": name], merge: true)
     }
 
     /// Save all nutrition goal values under `profile/goals`.

--- a/AthleteHub/AthleteHub/AuthViewModel.swift
+++ b/AthleteHub/AthleteHub/AuthViewModel.swift
@@ -52,6 +52,7 @@ class AuthViewModel: ObservableObject {
                 self.userProfile.uid = user.uid
                 self.userProfile.email = email
                 self.userProfile.name = name
+                self.userProfile.profileId = name
                 self.userProfile.birthDate = birthDate
                 self.userProfile.sex = sex
                 self.userProfile.height = height
@@ -62,6 +63,7 @@ class AuthViewModel: ObservableObject {
                 db.collection("users").document(user.uid).setData([
                     "email": email,
                     "name": name,
+                    "profileId": name,
                     "role": role
                 ])
 

--- a/AthleteHub/AthleteHub/CoachDashboardView.swift
+++ b/AthleteHub/AthleteHub/CoachDashboardView.swift
@@ -2,7 +2,10 @@ import SwiftUI
 import FirebaseFirestore
 
 struct AthleteRef: Identifiable {
+    /// Readable identifier for the athlete, typically their profile name.
     var id: String
+    /// Firebase UID for loading the full profile.
+    var uid: String
     var name: String
 }
 
@@ -57,7 +60,7 @@ struct CoachDashboardView: View {
                 }
 
                 List(athletes) { athlete in
-                    NavigationLink(destination: AthleteDetailView(athleteId: athlete.id)) {
+                    NavigationLink(destination: AthleteDetailView(athleteId: athlete.uid)) {
                         Text(athlete.name)
                     }
                 }
@@ -80,13 +83,19 @@ struct CoachDashboardView: View {
         }
         db.collection("users")
             .whereField("role", isEqualTo: "Athlete")
-            .order(by: "name")
+            .order(by: "profileId")
             .start(at: [trimmed])
             .end(at: [trimmed + "\u{f8ff}"])
             .limit(to: 10)
             .getDocuments { snapshot, _ in
                 if let docs = snapshot?.documents, !docs.isEmpty {
-                    searchResults = docs.map { AthleteRef(id: $0.documentID, name: $0.data()["name"] as? String ?? "Athlete") }
+                    searchResults = docs.map {
+                        AthleteRef(
+                            id: $0.data()["profileId"] as? String ?? "",
+                            uid: $0.documentID,
+                            name: $0.data()["name"] as? String ?? "Athlete"
+                        )
+                    }
                     errorMessage = nil
                 } else {
                     searchResults = []
@@ -99,11 +108,17 @@ struct CoachDashboardView: View {
         let db = Firestore.firestore()
         db.collection("users")
             .whereField("role", isEqualTo: "Athlete")
-            .order(by: "name")
+            .order(by: "profileId")
             .limit(to: 5)
             .getDocuments { snapshot, _ in
                 if let docs = snapshot?.documents {
-                    suggestedAthletes = docs.map { AthleteRef(id: $0.documentID, name: $0.data()["name"] as? String ?? "Athlete") }
+                    suggestedAthletes = docs.map {
+                        AthleteRef(
+                            id: $0.data()["profileId"] as? String ?? "",
+                            uid: $0.documentID,
+                            name: $0.data()["name"] as? String ?? "Athlete"
+                        )
+                    }
                 }
             }
     }
@@ -114,7 +129,10 @@ struct CoachDashboardView: View {
         guard !coachId.isEmpty else { return }
         db.collection("coaches").document(coachId)
             .collection("athletes").document(athlete.id)
-            .setData(["name": athlete.name]) { _ in
+            .setData([
+                "name": athlete.name,
+                "uid": athlete.uid
+            ]) { _ in
                 loadAthletes()
                 searchResults.removeAll { $0.id == athlete.id }
                 searchName = ""
@@ -129,7 +147,13 @@ struct CoachDashboardView: View {
             .collection("athletes")
             .getDocuments { snapshot, _ in
                 if let docs = snapshot?.documents {
-                    athletes = docs.map { AthleteRef(id: $0.documentID, name: $0.data()["name"] as? String ?? "Athlete") }
+                    athletes = docs.map {
+                        AthleteRef(
+                            id: $0.documentID,
+                            uid: $0.data()["uid"] as? String ?? "",
+                            name: $0.data()["name"] as? String ?? "Athlete"
+                        )
+                    }
                 }
             }
     }

--- a/AthleteHub/AthleteHub/UserSettingsFormView.swift
+++ b/AthleteHub/AthleteHub/UserSettingsFormView.swift
@@ -75,6 +75,7 @@ struct UserSettingsFormView: View {
             .navigationTitle("User Settings")
             .navigationBarItems(trailing: Button("Done") {
                 userProfile.name = username
+                userProfile.profileId = username
                 userProfile.sex = selectedSex
                 userProfile.height = height
                 userProfile.weight = weight


### PR DESCRIPTION
## Summary
- add `profileId` field to `UserProfile`
- persist `profileId` in Firestore and mirror to user root doc
- capture `profileId` during sign up
- update CoachDashboardView to search and store athletes by `profileId`
- update user settings to edit `profileId`

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686cd2a89bcc832bacfffb7d40cdf755