### PR TITLE
Add sign out button for coaches

### DIFF
--- a/AthleteHub/AthleteHub/CoachDashboardView.swift
+++ b/AthleteHub/AthleteHub/CoachDashboardView.swift
@@ -69,6 +69,22 @@ struct CoachDashboardView: View {
                     loadAthletes()
                     fetchSuggestedAthletes()
                 }
+
+                Button(action: {
+                    authViewModel.signOut()
+                }) {
+                    HStack {
+                        Image(systemName: "arrow.backward.square")
+                        Text("Sign Out")
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .foregroundColor(.white)
+                    .background(Color.red)
+                    .cornerRadius(8)
+                }
+                .padding(.horizontal)
+                .padding(.bottom)
             }
             .navigationTitle("Coach Dashboard")
         }


### PR DESCRIPTION
## Summary
- add sign out button on CoachDashboardView so coaches can log out

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686ce1cfac9c832b837ebbe5754485fe