### PR TITLE
Enable coach role navigation

### DIFF
--- a/AthleteHub/AthleteHub/CoachDashboardView.swift
+++ b/AthleteHub/AthleteHub/CoachDashboardView.swift
@@ -187,11 +187,35 @@ struct AthleteDetailView: View {
     @StateObject private var profile = UserProfile()
 
     var body: some View {
-        DashboardView()
-            .environmentObject(profile)
-            .onAppear {
-                profile.uid = athleteId
-                profile.loadFromFirestore()
-            }
+        TabView {
+            DashboardView()
+                .tabItem {
+                    Image(systemName: "house.fill")
+                    Text("Dashboard")
+                }
+
+            TrainingView()
+                .tabItem {
+                    Image(systemName: "figure.walk")
+                    Text("Training")
+                }
+
+            NutritionView()
+                .tabItem {
+                    Image(systemName: "fork.knife")
+                    Text("Nutrition")
+                }
+
+            RecoveryView()
+                .tabItem {
+                    Image(systemName: "bed.double")
+                    Text("Recovery")
+                }
+        }
+        .environmentObject(profile)
+        .onAppear {
+            profile.uid = athleteId
+            profile.loadFromFirestore()
+        }
     }
 }

--- a/AthleteHub/AthleteHub/MainView.swift
+++ b/AthleteHub/AthleteHub/MainView.swift
@@ -9,7 +9,38 @@ struct MainView: View {
         Group {
             if authViewModel.user != nil {
                 if authViewModel.userProfile.role == "Coach" {
-                    CoachDashboardView()
+                    TabView {
+                        CoachDashboardView()
+                            .tabItem {
+                                Image(systemName: "person.3.fill")
+                                Text("Athletes")
+                            }
+
+                        TrainingView()
+                            .tabItem {
+                                Image(systemName: "figure.walk")
+                                Text("Training")
+                            }
+
+                        NutritionView()
+                            .tabItem {
+                                Image(systemName: "fork.knife")
+                                Text("Nutrition")
+                            }
+
+                        RecoveryView()
+                            .tabItem {
+                                Image(systemName: "bed.double")
+                                Text("Recovery")
+                            }
+
+                        ProfileView()
+                            .tabItem {
+                                Image(systemName: "person.crop.circle")
+                                Text("Profile")
+                            }
+                    }
+                    .edgesIgnoringSafeArea(.all)
                 } else {
                     TabView {
                         DashboardView()


### PR DESCRIPTION
## Summary
- add tab navigation for users with Coach role
- allow coaches to view athlete data in a full tab interface

## Testing
- `swift test -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687b73ef75a0832bb86cd5b44626b57f