### PR TITLE
Fix coach views to load athlete data

### DIFF
--- a/AthleteHub/AthleteHub/AppData.swift
+++ b/AthleteHub/AthleteHub/AppData.swift
@@ -200,13 +200,19 @@ class UserProfile: ObservableObject {
     
     // MARK: - Firestore Integration
     /// Load persistent profile data and nutrition goals from Firestore.
-    func loadFromFirestore() {
-        guard let currentUser = Auth.auth().currentUser else { return }
-        self.uid = currentUser.uid
-        self.email = currentUser.email ?? ""
+    /// - Parameter uid: Optional UID to load a different user's profile. If nil,
+    ///   the currently authenticated user's data is loaded.
+    func loadFromFirestore(for uid: String? = nil) {
+        if let override = uid {
+            self.uid = override
+        } else if let currentUser = Auth.auth().currentUser {
+            self.uid = currentUser.uid
+            self.email = currentUser.email ?? ""
+        }
+        guard !self.uid.isEmpty else { return }
 
         let db = Firestore.firestore()
-        let profileRef = db.collection("users").document(uid).collection("profile")
+        let profileRef = db.collection("users").document(self.uid).collection("profile")
 
         profileRef.document("info").getDocument { snapshot, _ in
             if let data = snapshot?.data() {

--- a/AthleteHub/AthleteHub/AthleteDetailView.swift
+++ b/AthleteHub/AthleteHub/AthleteDetailView.swift
@@ -8,8 +8,7 @@ struct AthleteDetailView: View {
         DashboardView()
             .environmentObject(profile)
             .onAppear {
-                profile.uid = athleteId
-                profile.loadFromFirestore()
+                profile.loadFromFirestore(for: athleteId)
             }
     }
 }

--- a/AthleteHub/AthleteHub/CoachDashboardView.swift
+++ b/AthleteHub/AthleteHub/CoachDashboardView.swift
@@ -49,6 +49,17 @@ struct CoachDashboardView: View {
                             MetricCard(title: "Recovery", value: "\(m.recoveryScore)")
                         }
                         .padding(.horizontal)
+
+                        NavigationLink(
+                            destination: AthleteDetailView(athleteId: athletes[selectedIndex].uid)
+                        ) {
+                            Text("View Full Dashboard")
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.blue.opacity(0.2))
+                                .cornerRadius(8)
+                        }
+                        .padding(.horizontal)
                     } else if !athletes.isEmpty {
                         Text("No metrics available")
                             .foregroundColor(.secondary)
@@ -277,8 +288,7 @@ struct AthleteDetailView: View {
         }
         .environmentObject(profile)
         .onAppear {
-            profile.uid = athleteId
-            profile.loadFromFirestore()
+            profile.loadFromFirestore(for: athleteId)
         }
     }
 }


### PR DESCRIPTION
## Summary
- support loading a user profile for any UID
- show athlete dashboard from coach dashboard
- use new `loadFromFirestore(for:)` API in athlete detail views

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687cb2576bf4832b8b2a604c5e4868fb