### PR TITLE
Hide athlete picker for athlete role

### DIFF
--- a/AthleteHub/AthleteHub/DashboardView.swift
+++ b/AthleteHub/AthleteHub/DashboardView.swift
@@ -34,7 +34,9 @@ struct DashboardView: View {
         GeometryReader { geometry in
             ScrollView {
                 VStack(alignment: .leading, spacing: 32) {
-                    AthletePicker()
+                    if userProfile.role == "Coach" {
+                        AthletePicker()
+                    }
                     VStack(alignment: .leading, spacing: 4) {
                         Text("Hey, \(userProfile.name)!")
                             .font(.largeTitle)

--- a/AthleteHub/AthleteHub/NutritionView.swift
+++ b/AthleteHub/AthleteHub/NutritionView.swift
@@ -83,7 +83,9 @@ struct NutritionView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                AthletePicker()
+                if userProfile.role == "Coach" {
+                    AthletePicker()
+                }
                 // Header
                 HStack {
                     Text("Nutrition Dashboard")

--- a/AthleteHub/AthleteHub/RecoveryView.swift
+++ b/AthleteHub/AthleteHub/RecoveryView.swift
@@ -104,7 +104,9 @@ struct RecoveryView: View {
 
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                AthletePicker()
+                if userProfile.role == "Coach" {
+                    AthletePicker()
+                }
                 VStack(alignment: .leading, spacing: 12) {
                     HStack {
                         Text("Recovery Dashboard")

--- a/AthleteHub/AthleteHub/TrainingView.swift
+++ b/AthleteHub/AthleteHub/TrainingView.swift
@@ -11,6 +11,7 @@ struct TrainingView: View {
     @EnvironmentObject var healthManager: HealthManager
     @EnvironmentObject var scheduleManager: TrainingScheduleManager
     @EnvironmentObject var coachSelection: CoachSelection
+    @EnvironmentObject var userProfile: UserProfile
     @State private var showingSetGoals = false
     @State private var showingManualEntry = false
     
@@ -21,7 +22,9 @@ struct TrainingView: View {
         let backgroundColor = colorScheme == .dark ? customYellow.opacity(0.1) : Color(.systemGray6)
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
-                AthletePicker()
+                if userProfile.role == "Coach" {
+                    AthletePicker()
+                }
                 HStack {
                     Text("Training Dashboard")
                         .font(.title)


### PR DESCRIPTION
## Summary
- show `AthletePicker` only for coaches
- inject `UserProfile` into `TrainingView` so role can be checked

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687cbf0ee4c0832bb5a901ef3d99d513