### PR TITLE
Adjust Firestore path structure

### DIFF
--- a/AthleteHub/AthleteHub/AuthViewModel.swift
+++ b/AthleteHub/AthleteHub/AuthViewModel.swift
@@ -60,11 +60,15 @@ class AuthViewModel: ObservableObject {
                 self.userProfile.role = role
 
                 let db = Firestore.firestore()
-                db.collection("users").document(user.uid).setData([
-                    "email": email,
-                    "name": name,
-                    "profileId": name,
-                    "role": role
+                let rolePath = role.lowercased() == "coach" ? "coaches" : "athletes"
+                let userRef = db.collection("users").document(rolePath).collection(user.uid)
+                let parts = name.split(separator: " ", maxSplits: 1)
+                let first = String(parts.first ?? "")
+                let last = parts.count > 1 ? String(parts.last ?? "") : ""
+                userRef.document("profileData").setData([
+                    "firstName": first,
+                    "lastName": last,
+                    "email": email
                 ])
 
                 self.userProfile.saveToFirestore()

--- a/AthleteHub/AthleteHub/CoachDashboardView.swift
+++ b/AthleteHub/AthleteHub/CoachDashboardView.swift
@@ -132,7 +132,8 @@ struct CoachDashboardView: View {
         let today = formatter.string(from: Date())
         let db = Firestore.firestore()
         db.collection("users")
-            .document(athlete.uid)
+            .document("athletes")
+            .collection(athlete.uid)
             .collection("days")
             .document(today)
             .getDocument { snapshot, _ in
@@ -154,7 +155,7 @@ struct CoachDashboardView: View {
             searchResults = []
             return
         }
-        db.collectionGroup("profile")
+        db.collectionGroup("profileData")
             .whereField("role", isEqualTo: "Athlete")
             .limit(to: 50)
             .getDocuments { snapshot, _ in
@@ -182,7 +183,7 @@ struct CoachDashboardView: View {
 
     private func fetchSuggestedAthletes() {
         let db = Firestore.firestore()
-        db.collectionGroup("profile")
+        db.collectionGroup("profileData")
             .whereField("role", isEqualTo: "Athlete")
             .limit(to: 20)
             .getDocuments { snapshot, _ in

--- a/AthleteHub/AthleteHub/HealthManager.swift
+++ b/AthleteHub/AthleteHub/HealthManager.swift
@@ -253,8 +253,10 @@ class HealthManager: ObservableObject {
         let recovery = calculateOverallRecoveryScore()
         let trainingScore = calculateOverallTrainingScore()
 
+        let rolePath = "athletes"
         let dayDoc = db.collection("users")
-            .document(userId)
+            .document(rolePath)
+            .collection(userId)
             .collection("days")
             .document(dateString)
 
@@ -272,28 +274,21 @@ class HealthManager: ObservableObject {
         }
 
        let trainingMetrics: [String: Any] = [
-    "activeCalories": activeCalories ?? 0,
-    "totalCalories": totalCalories ?? 0,
-    "exerciseMinutes": exerciseMinutes ?? 0,
-    "distance": distance ?? 0,
-    "steps": steps ?? 0,
-    "vo2Max": vo2Max ?? 0,
-    "bodyMass": bodyMass ?? 0,
-    "height": height ?? 0,
-    "weeklyDistance": weeklyDistance ?? 0,
-    "weeklyHours": weeklyHours ?? 0
-]
+            "activeCalories": activeCalories ?? 0,
+            "totalCalories": totalCalories ?? 0,
+            "exerciseMinutes": exerciseMinutes ?? 0,
+            "distance": distance ?? 0,
+            "steps": steps ?? 0,
+            "vo2Max": vo2Max ?? 0,
+            "bodyMass": bodyMass ?? 0,
+            "height": height ?? 0,
+            "weeklyDistance": weeklyDistance ?? 0,
+            "weeklyHours": weeklyHours ?? 0
+        ]
 
 // Save metrics to the day's document
-dayDoc.collection("training")
+dayDoc.collection("trainingMetrics")
     .document("metrics")
-    .setData(trainingMetrics, merge: true)
-
-// Also save to user's trainingMetrics collection for historical tracking
-db.collection("users")
-    .document(userId)
-    .collection("trainingMetrics")
-    .document(dateString)
     .setData(trainingMetrics, merge: true)
 
 
@@ -309,7 +304,7 @@ db.collection("users")
             "bloodOxygenWeek": bloodOxygenWeek
         ]
 
-        dayDoc.collection("recovery").document("metrics")
+        dayDoc.collection("recoveryMetrics").document("metrics")
             .setData(recoveryMetrics, merge: true)
 
         let nutritionMetrics: [String: Any] = [
@@ -321,7 +316,7 @@ db.collection("users")
             "fiberIntake": fiberIntake ?? 0
         ]
 
-        dayDoc.collection("nutrition").document("metrics")
+        dayDoc.collection("nutritionMetrics").document("metrics")
             .setData(nutritionMetrics, merge: true)
     }
     
@@ -425,10 +420,11 @@ db.collection("users")
         ]
 
         db.collection("users")
-            .document(userId)
+            .document("athletes")
+            .collection(userId)
             .collection("days")
             .document(dateFormatter.string(from: date))
-            .collection("recovery")
+            .collection("recoveryMetrics")
             .document("metrics")
             .setData(recoveryData, merge: true)
 
@@ -1022,7 +1018,8 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
         guard let uid = Auth.auth().currentUser?.uid else { return }
         let newScore = TrainingScore(date: Date(), score: score)
         try? db.collection("users")
-            .document(uid)
+            .document("athletes")
+            .collection(uid)
             .collection("trainingScores")
             .document(newScore.id)
             .setData(from: newScore)
@@ -1033,7 +1030,8 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
         let calendar = Calendar.current
         if let existing = trainingScores.first(where: { calendar.isDate($0.date, inSameDayAs: Date()) }) {
             try? db.collection("users")
-                .document(uid)
+                .document("athletes")
+                .collection(uid)
                 .collection("trainingScores")
                 .document(existing.id)
                 .setData(["date": existing.date, "score": score], merge: true)
@@ -1049,7 +1047,8 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
         let startString = dateFormatter.string(from: startDate)
 
         db.collection("users")
-            .document(uid)
+            .document("athletes")
+            .collection(uid)
             .collection("days")
             .whereField("date", isGreaterThanOrEqualTo: startString)
             .order(by: "date", descending: false)
@@ -1083,8 +1082,9 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
 
         if let uid = Auth.auth().currentUser?.uid {
             db.collection("users")
-                .document(uid)
-                .collection("profile")
+                .document("athletes")
+                .collection(uid)
+                .collection("profileData")
                 .document("goals")
                 .setData([metric: value], merge: true)
         }
@@ -1097,8 +1097,9 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
 
         if let uid = Auth.auth().currentUser?.uid {
             db.collection("users")
-                .document(uid)
-                .collection("profile")
+                .document("athletes")
+                .collection(uid)
+                .collection("profileData")
                 .document("goals")
                 .getDocument { snapshot, _ in
                     if let data = snapshot?.data() as? [String: Double] {
@@ -1128,10 +1129,11 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
 
         let ref = Firestore.firestore()
             .collection("users")
-            .document(userId)
+            .document("athletes")
+            .collection(userId)
             .collection("days")
             .document(todayKey)
-            .collection("recovery")
+            .collection("recoveryMetrics")
             .document("metrics")
 
         let data: [String: Any] = [


### PR DESCRIPTION
## Summary
- organize user documents under `users/athletes` and `users/coaches`
- save profile info to new `profileData` collection
- update metric upload paths for days, training, recovery and nutrition
- search and load profiles from the updated locations

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dfba2c4f0832bbbe983de33179e58