### PR TITLE
Fix Firestore path chaining

### DIFF
--- a/AthleteHub/AthleteHub/AppData.swift
+++ b/AthleteHub/AthleteHub/AppData.swift
@@ -215,7 +215,10 @@ class UserProfile: ObservableObject {
 
         var loaded = false
         func load(from rolePath: String) {
-            let ref = db.collection("users").document(rolePath).collection(self.uid).collection("profileData")
+            let ref = db.collection("users")
+                .collection(rolePath)
+                .document(self.uid)
+                .collection("profileData")
             ref.document("info").getDocument { snapshot, _ in
                 if let data = snapshot?.data(), !loaded {
                     DispatchQueue.main.async {
@@ -282,8 +285,8 @@ class UserProfile: ObservableObject {
 
         Firestore.firestore()
             .collection("users")
-            .document(rolePath)
-            .collection(uid)
+            .collection(rolePath)
+            .document(uid)
             .collection("profileData")
             .document("info")
             .setData(fullData, merge: true)
@@ -304,8 +307,8 @@ class UserProfile: ObservableObject {
         let rolePath = role.lowercased() == "coach" ? "coaches" : "athletes"
         Firestore.firestore()
             .collection("users")
-            .document(rolePath)
-            .collection(uid)
+            .collection(rolePath)
+            .document(uid)
             .collection("profileData")
             .document("goals")
             .setData(data, merge: true)

--- a/AthleteHub/AthleteHub/AuthViewModel.swift
+++ b/AthleteHub/AthleteHub/AuthViewModel.swift
@@ -61,15 +61,20 @@ class AuthViewModel: ObservableObject {
 
                 let db = Firestore.firestore()
                 let rolePath = role.lowercased() == "coach" ? "coaches" : "athletes"
-                let userRef = db.collection("users").document(rolePath).collection(user.uid)
+                let userRef = db.collection("users")
+                    .collection(rolePath)
+                    .document(user.uid)
                 let parts = name.split(separator: " ", maxSplits: 1)
                 let first = String(parts.first ?? "")
                 let last = parts.count > 1 ? String(parts.last ?? "") : ""
-                userRef.document("profileData").setData([
-                    "firstName": first,
-                    "lastName": last,
-                    "email": email
-                ])
+                userRef
+                    .collection("profileData")
+                    .document("info")
+                    .setData([
+                        "firstName": first,
+                        "lastName": last,
+                        "email": email
+                    ])
 
                 self.userProfile.saveToFirestore()
             }

--- a/AthleteHub/AthleteHub/CoachDashboardView.swift
+++ b/AthleteHub/AthleteHub/CoachDashboardView.swift
@@ -132,8 +132,8 @@ struct CoachDashboardView: View {
         let today = formatter.string(from: Date())
         let db = Firestore.firestore()
         db.collection("users")
-            .document("athletes")
-            .collection(athlete.uid)
+            .collection("athletes")
+            .document(athlete.uid)
             .collection("days")
             .document(today)
             .getDocument { snapshot, _ in

--- a/AthleteHub/AthleteHub/HealthManager.swift
+++ b/AthleteHub/AthleteHub/HealthManager.swift
@@ -255,8 +255,8 @@ class HealthManager: ObservableObject {
 
         let rolePath = "athletes"
         let dayDoc = db.collection("users")
-            .document(rolePath)
-            .collection(userId)
+            .collection(rolePath)
+            .document(userId)
             .collection("days")
             .document(dateString)
 
@@ -420,8 +420,8 @@ dayDoc.collection("trainingMetrics")
         ]
 
         db.collection("users")
-            .document("athletes")
-            .collection(userId)
+            .collection("athletes")
+            .document(userId)
             .collection("days")
             .document(dateFormatter.string(from: date))
             .collection("recoveryMetrics")
@@ -1018,8 +1018,8 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
         guard let uid = Auth.auth().currentUser?.uid else { return }
         let newScore = TrainingScore(date: Date(), score: score)
         try? db.collection("users")
-            .document("athletes")
-            .collection(uid)
+            .collection("athletes")
+            .document(uid)
             .collection("trainingScores")
             .document(newScore.id)
             .setData(from: newScore)
@@ -1030,8 +1030,8 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
         let calendar = Calendar.current
         if let existing = trainingScores.first(where: { calendar.isDate($0.date, inSameDayAs: Date()) }) {
             try? db.collection("users")
-                .document("athletes")
-                .collection(uid)
+                .collection("athletes")
+                .document(uid)
                 .collection("trainingScores")
                 .document(existing.id)
                 .setData(["date": existing.date, "score": score], merge: true)
@@ -1047,8 +1047,8 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
         let startString = dateFormatter.string(from: startDate)
 
         db.collection("users")
-            .document("athletes")
-            .collection(uid)
+            .collection("athletes")
+            .document(uid)
             .collection("days")
             .whereField("date", isGreaterThanOrEqualTo: startString)
             .order(by: "date", descending: false)
@@ -1082,8 +1082,8 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
 
         if let uid = Auth.auth().currentUser?.uid {
             db.collection("users")
-                .document("athletes")
-                .collection(uid)
+                .collection("athletes")
+                .document(uid)
                 .collection("profileData")
                 .document("goals")
                 .setData([metric: value], merge: true)
@@ -1097,8 +1097,8 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
 
         if let uid = Auth.auth().currentUser?.uid {
             db.collection("users")
-                .document("athletes")
-                .collection(uid)
+                .collection("athletes")
+                .document(uid)
                 .collection("profileData")
                 .document("goals")
                 .getDocument { snapshot, _ in
@@ -1129,8 +1129,8 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
 
         let ref = Firestore.firestore()
             .collection("users")
-            .document("athletes")
-            .collection(userId)
+            .collection("athletes")
+            .document(userId)
             .collection("days")
             .document(todayKey)
             .collection("recoveryMetrics")


### PR DESCRIPTION
## Summary
- adjust Firestore path chaining in `AppData`, `AuthViewModel`, `CoachDashboardView` and `HealthManager`
- ensure nested documents/collections are accessed correctly

## Testing
- `swiftc -parse AthleteHub/AthleteHub/AppData.swift`
- `swiftc -parse AthleteHub/AthleteHub/AuthViewModel.swift`
- `swiftc -parse AthleteHub/AthleteHub/CoachDashboardView.swift` *(fails: consecutive statements on a line must be separated by ';')*
- `swiftc -parse AthleteHub/AthleteHub/HealthManager.swift`


------
https://chatgpt.com/codex/tasks/task_e_687e017de978832b9eae87ff24414647