### PR TITLE
Update Firestore paths

### DIFF
--- a/AthleteHub/AthleteHub/AppData.swift
+++ b/AthleteHub/AthleteHub/AppData.swift
@@ -215,8 +215,7 @@ class UserProfile: ObservableObject {
 
         var loaded = false
         func load(from rolePath: String) {
-            let ref = db.collection("users")
-                .collection(rolePath)
+            let ref = db.collection(rolePath)
                 .document(self.uid)
                 .collection("profileData")
             ref.document("info").getDocument { snapshot, _ in
@@ -284,7 +283,6 @@ class UserProfile: ObservableObject {
         fullData["lastName"] = last
 
         Firestore.firestore()
-            .collection("users")
             .collection(rolePath)
             .document(uid)
             .collection("profileData")
@@ -306,7 +304,6 @@ class UserProfile: ObservableObject {
 
         let rolePath = role.lowercased() == "coach" ? "coaches" : "athletes"
         Firestore.firestore()
-            .collection("users")
             .collection(rolePath)
             .document(uid)
             .collection("profileData")

--- a/AthleteHub/AthleteHub/AuthViewModel.swift
+++ b/AthleteHub/AthleteHub/AuthViewModel.swift
@@ -61,8 +61,7 @@ class AuthViewModel: ObservableObject {
 
                 let db = Firestore.firestore()
                 let rolePath = role.lowercased() == "coach" ? "coaches" : "athletes"
-                let userRef = db.collection("users")
-                    .collection(rolePath)
+                let userRef = db.collection(rolePath)
                     .document(user.uid)
                 let parts = name.split(separator: " ", maxSplits: 1)
                 let first = String(parts.first ?? "")

--- a/AthleteHub/AthleteHub/CoachDashboardView.swift
+++ b/AthleteHub/AthleteHub/CoachDashboardView.swift
@@ -131,8 +131,7 @@ struct CoachDashboardView: View {
         formatter.dateFormat = "yyyy-MM-dd"
         let today = formatter.string(from: Date())
         let db = Firestore.firestore()
-        db.collection("users")
-            .collection("athletes")
+        db.collection("athletes")
             .document(athlete.uid)
             .collection("days")
             .document(today)

--- a/AthleteHub/AthleteHub/HealthManager.swift
+++ b/AthleteHub/AthleteHub/HealthManager.swift
@@ -254,8 +254,7 @@ class HealthManager: ObservableObject {
         let trainingScore = calculateOverallTrainingScore()
 
         let rolePath = "athletes"
-        let dayDoc = db.collection("users")
-            .collection(rolePath)
+        let dayDoc = db.collection(rolePath)
             .document(userId)
             .collection("days")
             .document(dateString)
@@ -419,8 +418,7 @@ dayDoc.collection("trainingMetrics")
             "timestamp": Timestamp(date: date)
         ]
 
-        db.collection("users")
-            .collection("athletes")
+        db.collection("athletes")
             .document(userId)
             .collection("days")
             .document(dateFormatter.string(from: date))
@@ -1017,8 +1015,7 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
     func addTrainingScore(_ score: Int) {
         guard let uid = Auth.auth().currentUser?.uid else { return }
         let newScore = TrainingScore(date: Date(), score: score)
-        try? db.collection("users")
-            .collection("athletes")
+        try? db.collection("athletes")
             .document(uid)
             .collection("trainingScores")
             .document(newScore.id)
@@ -1029,8 +1026,7 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
         guard let uid = Auth.auth().currentUser?.uid else { return }
         let calendar = Calendar.current
         if let existing = trainingScores.first(where: { calendar.isDate($0.date, inSameDayAs: Date()) }) {
-            try? db.collection("users")
-                .collection("athletes")
+            try? db.collection("athletes")
                 .document(uid)
                 .collection("trainingScores")
                 .document(existing.id)
@@ -1046,8 +1042,7 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
         let startDate = Calendar.current.date(byAdding: .day, value: -6, to: Date()) ?? Date()
         let startString = dateFormatter.string(from: startDate)
 
-        db.collection("users")
-            .collection("athletes")
+        db.collection("athletes")
             .document(uid)
             .collection("days")
             .whereField("date", isGreaterThanOrEqualTo: startString)
@@ -1081,8 +1076,7 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
         UserDefaults.standard.set(dailyGoals, forKey: "dailyGoals")
 
         if let uid = Auth.auth().currentUser?.uid {
-            db.collection("users")
-                .collection("athletes")
+            db.collection("athletes")
                 .document(uid)
                 .collection("profileData")
                 .document("goals")
@@ -1096,8 +1090,7 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
         }
 
         if let uid = Auth.auth().currentUser?.uid {
-            db.collection("users")
-                .collection("athletes")
+            db.collection("athletes")
                 .document(uid)
                 .collection("profileData")
                 .document("goals")
@@ -1128,7 +1121,6 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
         let todayKey = dateFormatter.string(from: Date())
 
         let ref = Firestore.firestore()
-            .collection("users")
             .collection("athletes")
             .document(userId)
             .collection("days")


### PR DESCRIPTION
## Summary
- remove `users` prefix from Firestore path usage
- keep existing profile and metrics structure under the top level `athletes` and `coaches` collections

## Testing
- `swift --version`
- `swift build -v` *(fails: `Package.swift` missing)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ebc8cf830832bb0e800ba73606f3f