### PR TITLE
Refactor Firestore schema

### DIFF
--- a/AthleteHub/AthleteHub/AuthViewModel.swift
+++ b/AthleteHub/AthleteHub/AuthViewModel.swift
@@ -61,19 +61,20 @@ class AuthViewModel: ObservableObject {
 
                 let db = Firestore.firestore()
                 let rolePath = role.lowercased() == "coach" ? "coaches" : "athletes"
-                let userRef = db.collection(rolePath)
+                let userRef = db.collection("users")
+                    .document("roles")
+                    .collection(rolePath)
                     .document(user.uid)
                 let parts = name.split(separator: " ", maxSplits: 1)
                 let first = String(parts.first ?? "")
                 let last = parts.count > 1 ? String(parts.last ?? "") : ""
-                userRef
-                    .collection("profileData")
-                    .document("info")
-                    .setData([
+                userRef.setData([
+                    "profileData": [
                         "firstName": first,
                         "lastName": last,
                         "email": email
-                    ])
+                    ]
+                ], merge: true)
 
                 self.userProfile.saveToFirestore()
             }

--- a/AthleteHub/AthleteHub/CoachDashboardView.swift
+++ b/AthleteHub/AthleteHub/CoachDashboardView.swift
@@ -131,7 +131,9 @@ struct CoachDashboardView: View {
         formatter.dateFormat = "yyyy-MM-dd"
         let today = formatter.string(from: Date())
         let db = Firestore.firestore()
-        db.collection("athletes")
+        db.collection("users")
+            .document("roles")
+            .collection("athletes")
             .document(athlete.uid)
             .collection("days")
             .document(today)
@@ -154,8 +156,9 @@ struct CoachDashboardView: View {
             searchResults = []
             return
         }
-        db.collectionGroup("profileData")
-            .whereField("role", isEqualTo: "Athlete")
+        db.collection("users")
+            .document("roles")
+            .collection("athletes")
             .limit(to: 50)
             .getDocuments { snapshot, _ in
                 if let docs = snapshot?.documents {
@@ -167,7 +170,7 @@ struct CoachDashboardView: View {
                         searchResults = filtered.map {
                             AthleteRef(
                                 id: $0.data()["profileId"] as? String ?? "",
-                                uid: $0.reference.parent.parent?.documentID ?? "",
+                                uid: $0.documentID,
                                 name: $0.data()["name"] as? String ?? "Athlete"
                             )
                         }
@@ -182,8 +185,9 @@ struct CoachDashboardView: View {
 
     private func fetchSuggestedAthletes() {
         let db = Firestore.firestore()
-        db.collectionGroup("profileData")
-            .whereField("role", isEqualTo: "Athlete")
+        db.collection("users")
+            .document("roles")
+            .collection("athletes")
             .limit(to: 20)
             .getDocuments { snapshot, _ in
                 if let docs = snapshot?.documents {
@@ -195,7 +199,7 @@ struct CoachDashboardView: View {
                     suggestedAthletes = sorted.prefix(5).map {
                         AthleteRef(
                             id: $0.data()["profileId"] as? String ?? "",
-                            uid: $0.reference.parent.parent?.documentID ?? "",
+                            uid: $0.documentID,
                             name: $0.data()["name"] as? String ?? "Athlete"
                         )
                     }
@@ -207,7 +211,9 @@ struct CoachDashboardView: View {
         let db = Firestore.firestore()
         let coachId = authViewModel.userProfile.uid
         guard !coachId.isEmpty else { return }
-        db.collection("coaches").document(coachId)
+        db.collection("users")
+            .document("roles")
+            .collection("coaches").document(coachId)
             .collection("athletes").document(athlete.id)
             .setData([
                 "name": athlete.name,

--- a/AthleteHub/AthleteHub/CoachSelection.swift
+++ b/AthleteHub/AthleteHub/CoachSelection.swift
@@ -11,6 +11,8 @@ class CoachSelection: ObservableObject {
     func loadAthletes(for coachId: String) {
         guard !coachId.isEmpty else { return }
         Firestore.firestore()
+            .collection("users")
+            .document("roles")
             .collection("coaches").document(coachId)
             .collection("athletes")
             .getDocuments { snapshot, _ in


### PR DESCRIPTION
## Summary
- update Firestore paths to use a `users/roles` root with `coaches` and `athletes` collections
- store profile data as a map instead of a subcollection
- record daily metrics directly within each day document

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687ee3ffa26c832bbf15029b517019f5