### PR TITLE
Dynamic water goal based on trainings

### DIFF
--- a/AthleteHub/AthleteHub/NutritionView.swift
+++ b/AthleteHub/AthleteHub/NutritionView.swift
@@ -21,10 +21,16 @@ struct NutritionView: View {
     @EnvironmentObject var userProfile: UserProfile
     @EnvironmentObject var healthManager: HealthManager
     @EnvironmentObject var coachSelection: CoachSelection
+    @EnvironmentObject var scheduleManager: TrainingScheduleManager
     
     @State private var showingSetGoals = false
     @State private var showingManualEntry = false
     @State private var activeMetric: MetricType?
+
+    private func applyTrainingWaterAdjustment() {
+        let count = scheduleManager.trainings.filter { Calendar.current.isDateInToday($0.date) }.count
+        userProfile.adjustWaterGoal(forTrainingCount: count)
+    }
 
     private func percentage(from text: String?) -> Double? {
         guard let stripped = text?.replacingOccurrences(of: "%", with: ""),
@@ -210,6 +216,10 @@ struct NutritionView: View {
             }
             .onAppear {
                 userProfile.resetDailyNutritionIfNeeded()
+                applyTrainingWaterAdjustment()
+            }
+            .onReceive(scheduleManager.$trainings) { _ in
+                applyTrainingWaterAdjustment()
             }
         }
     }
@@ -776,7 +786,7 @@ struct NutritionRingCard: View {
                     userProfile.proteinGoal = proteinGoal
                     userProfile.carbsGoal = carbGoal
                     userProfile.fatGoal = fatGoal
-                    userProfile.waterGoal = waterGoal
+                    userProfile.updateWaterGoal(waterGoal)
                     userProfile.fiberGoal = fiberGoal
                     userProfile.saveGoalsToFirestore()
                     presentationMode.wrappedValue.dismiss()


### PR DESCRIPTION
## Summary
- add baseline water goal storage
- modify daily reset to restore baseline
- allow updating and adjusting water goal per training count
- update goal load/save to use new helpers
- adjust nutrition view to react to training schedule

## Testing
- `swiftc AthleteHub/AthleteHub/AppData.swift AthleteHub/AthleteHub/NutritionView.swift -o /tmp/test_binary`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_687f056a054c832bbb03b04eb5d5fb5c