### PR TITLE
Fix recovery metrics

### DIFF
--- a/AthleteHub/AthleteHub/HealthManager.swift
+++ b/AthleteHub/AthleteHub/HealthManager.swift
@@ -418,9 +418,9 @@ class HealthManager: ObservableObject {
         let score = calculateOverallRecoveryScore()
         let recoveryData: [String: Any] = [
             "sleepDuration": sleepDuration,
-            "sleepScore": sleepScore,
+            "sleepQualityScore": sleepScore,
             "hrv": hrv,
-            "restingHR": restingHR,
+            "restingHeartRate": restingHR,
             "stressLevel": stressLevel,
             "recoveryScore": score,
             "timestamp": Timestamp(date: date)


### PR DESCRIPTION
## Summary
- fix Firestore field names in recovery metric saving

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68803e9497ac832ba088d2f4be5185f9