### PR TITLE
Fix sleep duration and adapt hypnogram scale

### DIFF
--- a/AthleteHub/AthleteHub/HealthManager.swift
+++ b/AthleteHub/AthleteHub/HealthManager.swift
@@ -921,6 +921,7 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
 
             var totalSleep: Double = 0
             var awakeDuration: Double = 0
+            var inBedDuration: Double = 0
             var deepDuration: Double = 0
             var remDuration: Double = 0
             var lightDuration: Double = 0
@@ -928,6 +929,10 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
             var sleepStageDurations: [String: Double] = [:]
             var sleepStages: [SleepStage] = []
             
+            if let first = selectedSamples.first, let last = selectedSamples.last {
+                inBedDuration = last.endDate.timeIntervalSince(first.startDate) / 3600.0
+            }
+
             for sample in selectedSamples {
                 let duration = sample.endDate.timeIntervalSince(sample.startDate) / 3600.0
                 let stageValue = HKCategoryValueSleepAnalysis(rawValue: sample.value)
@@ -980,7 +985,8 @@ func fetchWorkoutDistance(completion: @escaping (Double?) -> Void) {
             }
 
             DispatchQueue.main.async {
-                self.sleepDuration = totalSleep
+                // Display total time in bed to better match the hypnogram width
+                self.sleepDuration = inBedDuration
                 self.sleepQuality = quality
                 self.sleepQualityScore = qualityScore
                 self.sleepStages = sleepStages

--- a/AthleteHub/AthleteHub/RecoveryView.swift
+++ b/AthleteHub/AthleteHub/RecoveryView.swift
@@ -789,8 +789,9 @@ struct SleepStageHypnogramView: View {
                 let chartWidth = geometry.size.width - labelWidth
                 let chartHeight = geometry.size.height - timeHeight
                 let rowHeight = chartHeight / CGFloat(stageOrder.count)
-                let chartHours: Double = 9
-                let totalSeconds = chartHours * 3600
+                // Make the timeline width adapt to the total duration of the
+                // displayed sleep stages rather than a fixed 9h window.
+                let totalSeconds = max(totalDuration, 3600) // ensure at least a 1h axis
                 let hourTicks = stride(from: 0.0, through: totalSeconds, by: 3600).map { $0 }
                 let groupedByStage = Dictionary(grouping: timelineEntries, by: { $0.stage })
 


### PR DESCRIPTION
## Summary
- compute total time in bed rather than just time asleep
- scale hypnogram x‑axis based on the data length

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688045a0d5f8832bb4e89a5958e0988e