### PR TITLE
Adjust button styles for Training and Recovery views

### DIFF
--- a/AthleteHub/AthleteHub/RecoveryView.swift
+++ b/AthleteHub/AthleteHub/RecoveryView.swift
@@ -128,7 +128,7 @@ var body: some View {
                             Button(action: {
                                 showingManualEntry = true
                             }) {
-                                Image(systemName: "pencil")
+                                Image(systemName: "square.and.pencil")
                                     .padding(8)
                                     .background(Color.purple.opacity(0.2))
                                     .clipShape(RoundedRectangle(cornerRadius: 8))

--- a/AthleteHub/AthleteHub/TrainingView.swift
+++ b/AthleteHub/AthleteHub/TrainingView.swift
@@ -35,15 +35,15 @@ struct TrainingView: View {
                         Button(action: { showingSetGoals = true }) {
                             Image(systemName: "target")
                                 .padding(8)
-                                .background(Color.yellow)
-                                .cornerRadius(8)
+                                .background(Color.yellow.opacity(0.2))
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
                         }
 
                         Button(action: { showingManualEntry = true }) {
                             Image(systemName: "square.and.pencil")
                                 .padding(8)
-                                .background(Color.yellow)
-                                .cornerRadius(8)
+                                .background(Color.yellow.opacity(0.2))
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- make goals and manual entry buttons transparent on TrainingView
- change RecoveryView manual entry icon to match other views

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68805da9f0d0832b9b7dc7b9a3048008